### PR TITLE
add benchmark for HexRanges vs native

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -57,3 +57,27 @@ func BenchmarkPolyfill(b *testing.B) {
 		h3idxs = Polyfill(validGeopolygonWithHoles, 6)
 	}
 }
+
+var (
+	hexes           [][]H3Index
+	hexRangesCenter = H3Index(0x8928308280fffff)
+	hexRangeK       = 5
+)
+
+func BenchmarkHexRangesNative(b *testing.B) {
+	group := KRing(hexRangesCenter, hexRangeK)
+	for n := 0; n < b.N; n++ {
+		hexes = make([][]H3Index, len(group))
+		for i, originHex := range group {
+			out, _ := HexRange(originHex, hexRangeK)
+			hexes[i] = out
+		}
+	}
+}
+
+func BenchmarkHexRangesC(b *testing.B) {
+	group := KRing(hexRangesCenter, hexRangeK)
+	for n := 0; n < b.N; n++ {
+		hexes, _ = HexRanges(group, hexRangeK)
+	}
+}


### PR DESCRIPTION
```
➜  h3-go git:(master) ✗ go test -bench=".*Ranges.*" .
goos: darwin
goarch: amd64
pkg: github.com/uber/h3-go
BenchmarkHexRangesNative-8          5000            245896 ns/op
BenchmarkHexRangesFromC-8          30000             47381 ns/op
PASS
ok      github.com/uber/h3-go   3.181s
```