### PR TITLE
Modified the Travis configuration file to enable automated FOSSA scans.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,7 @@ go:
 
 before_install:
   - go get github.com/mattn/goveralls
+  - "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | sudo bash"
 script:
   - $GOPATH/bin/goveralls -service=travis-ci
+  - fossa


### PR DESCRIPTION
Hello, I'm from FOSSA and I'm working with the Uber OSPO to automate license scanning. In addition to the changes in this PR, we may also need to add an API key as an environmental variable in the build environment. 