### PR TITLE
Handle maxUncompactSize error case in Uncompact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ fixes via patches with patch version bumps.
 
 ## Unreleased
 
+### Fixed
 * Handle error case in Uncompact
 
 ## v3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,13 @@ fixes via patches with patch version bumps.
 
 ## Unreleased
 
+### Changed
+
+* [breaking] `Uncompat` now returns `([]H3Index, error)` instead of `[]H3Index` to accommodate error scenario from C API.
+
 ### Fixed
-* Handle error case in Uncompact
+
+* panic when using `Uncompact` with invalid resolutions.
 
 ## v3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ fixes via patches with patch version bumps.
 
 ## Unreleased
 
-Nothing yet.
+* Handle error case in Uncompact
 
 ## v3.0.0
 

--- a/h3.go
+++ b/h3.go
@@ -48,6 +48,9 @@ var (
 	// and cannot handle it.
 	ErrPentagonEncountered = errors.New("pentagon encountered")
 
+	// ErrInvalidResolution is returned when the requested resolution is not valid
+	ErrInvalidResolution = errors.New("resolution invalid")
+
 	// conversion units for faster maths
 	deg2rad = math.Pi / 180.0
 	rad2deg = 180.0 / math.Pi
@@ -274,15 +277,20 @@ func Compact(in []H3Index) []H3Index {
 
 // Uncompact splits every `H3Index` in `in` if its resolution is greater than
 // `res` recursively. Returns all the `H3Index`es at resolution `res`.
-func Uncompact(in []H3Index, res int) []H3Index {
+func Uncompact(in []H3Index, res int) ([]H3Index, error) {
 	cin := h3SliceToC(in)
 	maxUncompactSz := C.maxUncompactSize(&cin[0], C.int(len(in)), C.int(res))
+	if maxUncompactSz < 0 {
+		// A size of less than zero indicates an error uncompacting such as the
+		// requested resolution being less than the resolution of the hexagons.
+		return nil, ErrInvalidResolution
+	}
 	cout := make([]C.H3Index, maxUncompactSz)
 	C.uncompact(
 		&cin[0], C.int(len(in)),
 		&cout[0], maxUncompactSz,
 		C.int(res))
-	return h3SliceFromC(cout)
+	return h3SliceFromC(cout), nil
 }
 
 // --- REGIONS ---

--- a/h3_test.go
+++ b/h3_test.go
@@ -282,8 +282,20 @@ func TestUncompact(t *testing.T) {
 	res := Resolution(validH3Index) - 1
 	parent := ToParent(validH3Index, res)
 
-	out := Uncompact([]H3Index{parent}, res+1)
+	out, err := Uncompact([]H3Index{parent}, res+1)
+	assert.NoError(t, err)
 	assertHexIn(t, validH3Index, out)
+}
+
+func TestUncompactError(t *testing.T) {
+	t.Parallel()
+	res := Resolution(validH3Index) - 1
+	parent := ToParent(validH3Index, res)
+
+	// use a resolution that is too small
+	out, err := Uncompact([]H3Index{parent}, res-1)
+	assert.Nil(t, out)
+	assert.Equal(t, ErrInvalidResolution, err)
 }
 
 func TestIsResClassIII(t *testing.T) {


### PR DESCRIPTION
The C maxUncompactSize function used in Uncompact can return -1 as the maximum size when an error (such as the resolution being specified is smaller than that of the hexagons being uncompacted). This changes the function signature to return an error from Uncompact in this case instead of the current behavior of causing a panic when an attempt is made to make a slice of -1 size.