### PR TITLE
remove support for Go 1.9, add 1.12 and 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,10 @@
 language: go
 
 go:
-  - "1.9.x"
   - "1.10.x"
   - "1.11.x"
+  - "1.12.x"
+  - "1.13.x"
 
 before_install:
   - go get github.com/mattn/goveralls


### PR DESCRIPTION
go version 1.9 is not compatible with GOMODULES and CGO.  There is a
build error when trying to upgrade that is not present in versions
10 on.