### PR TITLE
Update the readme example to use v3 import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ glide install github.com/uber/h3-go
 ## Quickstart
 
 ```go
-import "github.com/uber/h3-go"
+import "github.com/uber/h3-go/v3"
 
 func ExampleFromGeo() {
 	geo := h3.GeoCoord{


### PR DESCRIPTION
Update the example in the readme to include the full import path to the v3 path to ensure that go mod correctly retrieves the latest versions as highlighted by #42