### PR TITLE
Add faces, distance and miscellaneous functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ This project tracks the **major** and **minor** versions set by
 [`h3`](github.com/uber/h3), and introduces backwards-compatible updates and/or
 fixes via patches with patch version bumps.
 
+## Unreleased
+
+### Added
+
+* Functions to cover full functionality
+  * `Res0IndexCount`
+  * `GetRes0Indexes`
+  * `DistanceBetween`
+  * `ToCenterChild`
+  * `MaxFaceCount`
+  * `GetFaces`
+  * `PentagonIndexCount`
+  * `GetPentagonIndexes`
+  * `HexAreaKm2`
+  * `HexAreaM2`
+  * `PointDistRads`
+  * `PointDistKm`
+  * `PointDistM`
+  * `CellAreaRads2`
+  * `CellAreaKm2`
+  * `CellAreaM2`
+  * `EdgeLengthKm`
+  * `EdgeLengthM`
+  * `ExactEdgeLengthRads`
+  * `ExactEdgeLengthKm`
+  * `ExactEdgeLengthM`
+  * `NumHexagons`
+
 ## 3.7.0
 
 ### Added

--- a/v3/h3.go
+++ b/v3/h3.go
@@ -428,6 +428,122 @@ func Line(start, end H3Index) []H3Index {
 	return h3SliceFromC(cout)
 }
 
+// HexAreaKm2 returns the average hexagon area in square kilometers at the given resolution.
+func HexAreaKm2(resolution int) float64 {
+	return float64(C.hexAreaKm2(C.int(resolution)))
+}
+
+// HexAreaM2 returns the average hexagon area in square meters at the given resolution.
+func HexAreaM2(resolution int) float64 {
+	return float64(C.hexAreaM2(C.int(resolution)))
+}
+
+// PointDistRads returns the "great circle" or "haversine" distance between pairs of GeoCoord points (lat/lng pairs) in radians.
+func PointDistRads(a, b GeoCoord) float64 {
+	return float64(C.pointDistRads(a.toCPtr(), b.toCPtr()))
+}
+
+// PointDistKm returns the "great circle" or "haversine" distance between pairs of GeoCoord points (lat/lng pairs) in kilometers.
+func PointDistKm(a, b GeoCoord) float64 {
+	return float64(C.pointDistKm(a.toCPtr(), b.toCPtr()))
+}
+
+// PointDistM returns the "great circle" or "haversine" distance between pairs of GeoCoord points (lat/lng pairs) in meters.
+func PointDistM(a, b GeoCoord) float64 {
+	return float64(C.pointDistM(a.toCPtr(), b.toCPtr()))
+}
+
+// CellAreaRads2 returns the exact area of specific cell in square radians.
+func CellAreaRads2(h H3Index) float64 {
+	return float64(C.cellAreaRads2(h))
+}
+
+// CellAreaKm2 returns the exact area of specific cell in square kilometers.
+func CellAreaKm2(h H3Index) float64 {
+	return float64(C.cellAreaKm2(h))
+}
+
+// CellAreaM2 returns the exact area of specific cell in square meters.
+func CellAreaM2(h H3Index) float64 {
+	return float64(C.cellAreaM2(h))
+}
+
+// EdgeLengthKm returns the average hexagon edge length in kilometers at the given resolution.
+func EdgeLengthKm(resolution int) float64 {
+	return float64(C.edgeLengthKm(C.int(resolution)))
+}
+
+// EdgeLengthM returns the average hexagon edge length in meters at the given resolution.
+func EdgeLengthM(resolution int) float64 {
+	return float64(C.edgeLengthM(C.int(resolution)))
+}
+
+// ExactEdgeLengthRads returns the exact edge length of specific unidirectional edge in radians.
+func ExactEdgeLengthRads(h H3Index) float64 {
+	return float64(C.exactEdgeLengthRads(h))
+}
+
+// ExactEdgeLengthKm returns the exact edge length of specific unidirectional edge in kilometers.
+func ExactEdgeLengthKm(h H3Index) float64 {
+	return float64(C.exactEdgeLengthKm(h))
+}
+
+// ExactEdgeLengthM returns the exact edge length of specific unidirectional edge in meters.
+func ExactEdgeLengthM(h H3Index) float64 {
+	return float64(C.exactEdgeLengthM(h))
+}
+
+// NumHexagons returns the number of unique H3 indexes at the given resolution.
+func NumHexagons(resolution int) int {
+	return int(C.numHexagons(C.int(resolution)))
+}
+
+// Res0IndexCount returns the number of resolution 0 H3 indexes.
+func Res0IndexCount() int {
+	return int(C.res0IndexCount())
+}
+
+// GetRes0Indexes returns all the resolution 0 H3 indexes.
+func GetRes0Indexes() []H3Index {
+	out := make([]C.H3Index, Res0IndexCount())
+	C.getRes0Indexes(&out[0])
+	return h3SliceFromC(out)
+}
+
+// DistanceBetween returns the distance in grid cells between the two indexes
+func DistanceBetween(origin, dest H3Index) int {
+	return int(C.h3Distance(origin, dest))
+}
+
+// ToCenterChild returns the center child (finer) index contained by h at resolution.
+func ToCenterChild(h H3Index, resolution int) H3Index {
+	return C.h3ToCenterChild(h, C.int(resolution))
+}
+
+// MaxFaceCount returns the maximum number of icosahedron faces the given H3 index may intersect.
+func MaxFaceCount(h H3Index) int {
+	return int(C.maxFaceCount(h))
+}
+
+// GetFaces returns all icosahedron faces intersected by a given H3 index
+func GetFaces(h H3Index) []int {
+	out := make([]C.int, MaxFaceCount(h))
+	C.h3GetFaces(h, &out[0])
+	return intSliceFromC(out)
+}
+
+// PentagonIndexCount returns the number of pentagon H3 indexes per resolution (This is always 12)
+func PentagonIndexCount() int {
+	return int(C.pentagonIndexCount())
+}
+
+// GetPentagonIndex returns all the pentagon H3 indexes at the specified resolution.
+func GetPentagonIndexes(resolution int) []H3Index {
+	out := make([]C.H3Index, PentagonIndexCount())
+	C.getPentagonIndexes(C.int(resolution), &out[0])
+	return h3SliceFromC(out)
+}
+
 func geoCoordFromC(cg C.GeoCoord) GeoCoord {
 	g := GeoCoord{}
 	g.Latitude = rad2deg * float64(cg.lat)
@@ -460,6 +576,19 @@ func h3SliceToC(hs []H3Index) []C.H3Index {
 	out := make([]C.H3Index, len(hs))
 	for i, h := range hs {
 		out[i] = h
+	}
+	return out
+}
+
+func intSliceFromC(chs []C.int) []int {
+	out := make([]int, 0, len(chs))
+	for _, ch := range chs {
+		// C API returns a sparse array of indexes in the event pentagons and
+		// deleted sequences are encountered.
+		if ch == -1 {
+			continue
+		}
+		out = append(out, int(ch))
 	}
 	return out
 }

--- a/v3/h3_test.go
+++ b/v3/h3_test.go
@@ -148,6 +148,13 @@ var (
 			0x872f5a329ffffff,
 		},
 	}
+
+	validGeoCoordB = GeoCoord{
+		Latitude:  37.775705522929044,
+		Longitude: -122.41812765598296,
+	}
+
+	validEdge = H3Index(0x1250dab73fffffff)
 )
 
 func TestFromGeo(t *testing.T) {
@@ -504,6 +511,251 @@ func TestLine(t *testing.T) {
 	for i := 0; i < len(line)-1; i++ {
 		assert.True(t, AreNeighbors(line[i], line[i+1]))
 	}
+}
+
+func TestHexAreaKm2(t *testing.T) {
+	t.Parallel()
+	t.Run("min resolution", func(t *testing.T) {
+		t.Parallel()
+		area := HexAreaKm2(0)
+
+		assert.Equal(t, float64(4250546.848), area)
+	})
+	t.Run("max resolution", func(t *testing.T) {
+		t.Parallel()
+		area := HexAreaKm2(15)
+
+		assert.Equal(t, float64(0.0000009), area)
+	})
+	t.Run("mid resolution", func(t *testing.T) {
+		t.Parallel()
+		area := HexAreaKm2(8)
+
+		assert.Equal(t, float64(0.7373276), area)
+	})
+}
+
+func TestHexAreaM2(t *testing.T) {
+	t.Parallel()
+	t.Run("min resolution", func(t *testing.T) {
+		t.Parallel()
+		area := HexAreaM2(0)
+
+		assert.Equal(t, float64(4250550000000), area)
+	})
+	t.Run("max resolution", func(t *testing.T) {
+		t.Parallel()
+		area := HexAreaM2(15)
+
+		assert.Equal(t, float64(0.9), area)
+	})
+	t.Run("mid resolution", func(t *testing.T) {
+		t.Parallel()
+		area := HexAreaM2(8)
+
+		assert.Equal(t, float64(737327.6), area)
+	})
+}
+
+func TestPointDistRads(t *testing.T) {
+	t.Parallel()
+	distance := PointDistRads(validGeoCoord, validGeoCoordB)
+	assert.Equal(t, float64(0.6796147656451452), distance)
+}
+
+func TestPointDistKm(t *testing.T) {
+	t.Parallel()
+	distance := PointDistKm(validGeoCoord, validGeoCoordB)
+	assert.Equal(t, float64(4329.830552183446), distance)
+}
+
+func TestPointDistM(t *testing.T) {
+	t.Parallel()
+	distance := PointDistM(validGeoCoord, validGeoCoordB)
+	assert.Equal(t, float64(4329830.5521834465), distance)
+}
+
+func TestCellAreaRads2(t *testing.T) {
+	t.Parallel()
+	distance := CellAreaRads2(validH3Index)
+	assert.Equal(t, float64(0.000006643967854567278), distance)
+}
+
+func TestCellAreaKm2(t *testing.T) {
+	t.Parallel()
+	distance := CellAreaKm2(validH3Index)
+	assert.Equal(t, float64(269.6768779509321), distance)
+}
+
+func TestCellAreaM2(t *testing.T) {
+	t.Parallel()
+	distance := CellAreaM2(validH3Index)
+	assert.Equal(t, float64(269676877.95093215), distance)
+}
+
+func TestEdgeLengthKm(t *testing.T) {
+	t.Parallel()
+	t.Run("min resolution", func(t *testing.T) {
+		t.Parallel()
+		area := EdgeLengthKm(0)
+
+		assert.Equal(t, float64(1107.712591), area)
+	})
+	t.Run("max resolution", func(t *testing.T) {
+		t.Parallel()
+		area := EdgeLengthKm(15)
+
+		assert.Equal(t, float64(0.000509713), area)
+	})
+	t.Run("mid resolution", func(t *testing.T) {
+		t.Parallel()
+		area := EdgeLengthKm(8)
+
+		assert.Equal(t, float64(0.461354684), area)
+	})
+}
+
+func TestEdgeLengthM(t *testing.T) {
+	t.Parallel()
+	t.Run("min resolution", func(t *testing.T) {
+		t.Parallel()
+		area := EdgeLengthM(0)
+
+		assert.Equal(t, float64(1107712.591), area)
+	})
+	t.Run("max resolution", func(t *testing.T) {
+		t.Parallel()
+		area := EdgeLengthM(15)
+
+		assert.Equal(t, float64(0.509713273), area)
+	})
+	t.Run("mid resolution", func(t *testing.T) {
+		t.Parallel()
+		area := EdgeLengthM(8)
+
+		assert.Equal(t, float64(461.3546837), area)
+	})
+}
+
+func TestExactEdgeLengthRads(t *testing.T) {
+	t.Parallel()
+
+	distance := ExactEdgeLengthRads(validEdge)
+	assert.Equal(t, float64(0.001569665746947077), distance)
+}
+
+func TestExactEdgeLengthKm(t *testing.T) {
+	t.Parallel()
+
+	distance := ExactEdgeLengthKm(validEdge)
+	assert.Equal(t, float64(10.00035174544159), distance)
+}
+
+func TestExactEdgeLengthM(t *testing.T) {
+	t.Parallel()
+
+	distance := ExactEdgeLengthM(validEdge)
+	assert.Equal(t, float64(10000.351745441589), distance)
+}
+
+func TestNumHexagons(t *testing.T) {
+	t.Parallel()
+	t.Run("min resolution", func(t *testing.T) {
+		t.Parallel()
+		count := NumHexagons(0)
+
+		assert.Equal(t, 122, count)
+	})
+	t.Run("max resolution", func(t *testing.T) {
+		t.Parallel()
+		count := NumHexagons(15)
+
+		assert.Equal(t, 569707381193162, count)
+	})
+	t.Run("mid resolution", func(t *testing.T) {
+		t.Parallel()
+		count := NumHexagons(8)
+
+		assert.Equal(t, 691776122, count)
+	})
+}
+
+func TestRes0IndexCount(t *testing.T) {
+	t.Parallel()
+	count := Res0IndexCount()
+
+	assert.Equal(t, 122, count)
+}
+
+func TestGetRes0Indexes(t *testing.T) {
+	t.Parallel()
+	indexes := GetRes0Indexes()
+
+	assert.Equal(t, 122, len(indexes))
+	assert.Equal(t, H3Index(0x8001fffffffffff), indexes[0])
+	assert.Equal(t, H3Index(0x80f3fffffffffff), indexes[121])
+}
+
+func TestDistanceBetween(t *testing.T) {
+	t.Parallel()
+	distance := DistanceBetween(validLineStartIndex, validLineEndIndex)
+
+	assert.Equal(t, 1823, distance)
+}
+
+func TestToCenterChild(t *testing.T) {
+	t.Parallel()
+
+	child := ToCenterChild(validH3Index, 15)
+
+	assert.Equal(t, H3Index(0x8f0dab600000000), child)
+}
+
+func TestMaxFaceCount(t *testing.T) {
+	t.Parallel()
+
+	faces := MaxFaceCount(validH3Index)
+
+	assert.Equal(t, 2, faces)
+}
+
+func TestGetFaces(t *testing.T) {
+	t.Parallel()
+
+	faces := GetFaces(validH3Rings1[1][1])
+
+	assert.Equal(t, 1, len(faces))
+	assert.Equal(t, 1, faces[0])
+}
+
+func TestPentagonIndexCount(t *testing.T) {
+	t.Parallel()
+
+	pentagonCount := PentagonIndexCount()
+
+	assert.Equal(t, 12, pentagonCount)
+}
+
+func TestGetPentagonIndexes(t *testing.T) {
+	t.Parallel()
+	t.Run("min resolution", func(t *testing.T) {
+		t.Parallel()
+		pentagons := GetPentagonIndexes(0)
+
+		assert.Equal(t, 12, len(pentagons))
+	})
+	t.Run("max resolution", func(t *testing.T) {
+		t.Parallel()
+		pentagons := GetPentagonIndexes(15)
+
+		assert.Equal(t, 12, len(pentagons))
+	})
+	t.Run("mid resolution", func(t *testing.T) {
+		t.Parallel()
+		pentagons := GetPentagonIndexes(8)
+
+		assert.Equal(t, 12, len(pentagons))
+	})
 }
 
 func almostEqual(t *testing.T, expected, actual interface{}, msgAndArgs ...interface{}) {


### PR DESCRIPTION
Add functions to cover all functions in the current version of H3 except the two experimental prefixed functions (experimentalH3ToLocalIj and experimentalLocalIjToH3)

At a minimum it covers the functions mentioned in #29 and #44