### PR TITLE
added cellToChildPos and childPosToCell

### DIFF
--- a/h3.go
+++ b/h3.go
@@ -634,11 +634,7 @@ func CellToChildPos(a Cell, resolution int) int {
 // ChildPos returns the position of the cell within an ordered list of all children of the cell's parent
 // at the specified resolution.
 func (c Cell) ChildPos(resolution int) int {
-	var out C.int64_t
-
-	C.cellToChildPos(C.H3Index(c), C.int(resolution), &out)
-
-	return int(out)
+	return CellToChildPos(c, resolution)
 }
 
 func GridDistance(a, b Cell) int {

--- a/h3.go
+++ b/h3.go
@@ -27,6 +27,7 @@ package h3
 #include <h3_h3Index.h>
 */
 import "C"
+
 import (
 	"errors"
 	"fmt"
@@ -602,6 +603,42 @@ func UncompactCells(in []Cell, resolution int) []Cell {
 		C.int(resolution))
 
 	return cellsFromC(cout, false, true)
+}
+
+// ChildPosToCell returns the child of cell a at a given position within an ordered list of all
+// children at the specified resolution.
+func ChildPosToCell(position int, a Cell, resolution int) Cell {
+	var out C.H3Index
+
+	C.childPosToCell(C.int64_t(position), C.H3Index(a), C.int(resolution), &out)
+
+	return Cell(out)
+}
+
+// ChildPosToCell returns the child cell at a given position within an ordered list of all
+// children at the specified resolution.
+func (c Cell) ChildPosToCell(position int, resolution int) Cell {
+	return ChildPosToCell(position, c, resolution)
+}
+
+// CellToChildPos returns the position of the cell a within an ordered list of all children of the cell's parent
+// at the specified resolution res.
+func CellToChildPos(a Cell, resolution int) int {
+	var out C.int64_t
+
+	C.cellToChildPos(C.H3Index(a), C.int(resolution), &out)
+
+	return int(out)
+}
+
+// ChildPos returns the position of the cell within an ordered list of all children of the cell's parent
+// at the specified resolution res.
+func (c Cell) ChildPos(resolution int) int {
+	var out C.int64_t
+
+	C.cellToChildPos(C.H3Index(c), C.int(resolution), &out)
+
+	return int(out)
 }
 
 func GridDistance(a, b Cell) int {

--- a/h3.go
+++ b/h3.go
@@ -622,7 +622,7 @@ func (c Cell) ChildPosToCell(position int, resolution int) Cell {
 }
 
 // CellToChildPos returns the position of the cell a within an ordered list of all children of the cell's parent
-// at the specified resolution res.
+// at the specified resolution.
 func CellToChildPos(a Cell, resolution int) int {
 	var out C.int64_t
 
@@ -632,7 +632,7 @@ func CellToChildPos(a Cell, resolution int) int {
 }
 
 // ChildPos returns the position of the cell within an ordered list of all children of the cell's parent
-// at the specified resolution res.
+// at the specified resolution.
 func (c Cell) ChildPos(resolution int) int {
 	var out C.int64_t
 

--- a/h3_test.go
+++ b/h3_test.go
@@ -234,17 +234,17 @@ func TestUncompactCells(t *testing.T) {
 func TestChildPosToCell(t *testing.T) {
 	t.Parallel()
 
-	childrens := validCell.Children(6)
+	children := validCell.Children(6)
 
-	assertEqual(t, childrens[0], validCell.ChildPosToCell(0, 6))
+	assertEqual(t, children[0], validCell.ChildPosToCell(0, 6))
 }
 
 func TestChildPos(t *testing.T) {
 	t.Parallel()
 
-	childrens := validCell.Children(7)
+	children := validCell.Children(7)
 
-	assertEqual(t, 32, childrens[32].ChildPos(5))
+	assertEqual(t, 32, children[32].ChildPos(validCell.Resolution()))
 }
 
 func TestIsResClassIII(t *testing.T) {

--- a/h3_test.go
+++ b/h3_test.go
@@ -231,6 +231,22 @@ func TestUncompactCells(t *testing.T) {
 	assertCellIn(t, validCell, out)
 }
 
+func TestChildPosToCell(t *testing.T) {
+	t.Parallel()
+
+	childrens := validCell.Children(6)
+
+	assertEqual(t, childrens[0], validCell.ChildPosToCell(0, 6))
+}
+
+func TestChildPos(t *testing.T) {
+	t.Parallel()
+
+	childrens := validCell.Children(7)
+
+	assertEqual(t, 32, childrens[32].ChildPos(5))
+}
+
 func TestIsResClassIII(t *testing.T) {
 	t.Parallel()
 
@@ -767,6 +783,7 @@ func assertFalse(t *testing.T, b bool) {
 	t.Helper()
 	assertEqual(t, false, b)
 }
+
 func assertTrue(t *testing.T, b bool) {
 	t.Helper()
 	assertEqual(t, true, b)

--- a/h3_test.go
+++ b/h3_test.go
@@ -237,6 +237,7 @@ func TestChildPosToCell(t *testing.T) {
 	children := validCell.Children(6)
 
 	assertEqual(t, children[0], validCell.ChildPosToCell(0, 6))
+	assertEqual(t, children[0], ChildPosToCell(0, validCell, 6))
 }
 
 func TestChildPos(t *testing.T) {
@@ -245,6 +246,7 @@ func TestChildPos(t *testing.T) {
 	children := validCell.Children(7)
 
 	assertEqual(t, 32, children[32].ChildPos(validCell.Resolution()))
+	assertEqual(t, 32, CellToChildPos(children[32], validCell.Resolution()))
 }
 
 func TestIsResClassIII(t *testing.T) {


### PR DESCRIPTION
4.1.0 comes with additional features to compute a child cell at a specific positions without generating all children in memory.

This PR adds:

```go
func ChildPosToCell(position int, a Cell, resolution int) Cell
func (c Cell) ChildPosToCell(position int, resolution int) Cell 

func CellToChildPos(a Cell, resolution int) int 
func (c Cell) ChildPos(resolution int) int 
```