### PR TITLE
feat: Implement GridDisksUnsafe, GridDiskDistancesUnsafe, GridDiskDistancesSafe

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,55 +82,58 @@ func ExampleLatLngToCell() {
 
 ## Bindings
 
-| C API                        | Go API                                             |
-| ---------------------------- | -------------------------------------------------- |
-| `latLngToCell`               | `LatLngToCell`, `LatLng#Cell`                      |
-| `cellToLatLng`               | `CellToLatLng`, `Cell#LatLng`                      |
-| `cellToBoundary`             | `CellToBoundary`, `Cell#Boundary`                  |
-| `gridDisk`                   | `GridDisk`, `Cell#GridDisk`                        |
-| `gridDiskDistances`          | `GridDiskDistances`, `Cell#GridDiskDistances`      |
-| `gridRingUnsafe`             | N/A                                                |
-| `polygonToCells`             | `PolygonToCells`, `GeoPolygon#Cells`               |
-| `cellsToMultiPolygon`        | `CellsToMultiPolygon`
-| `degsToRads`                 | `DegsToRads`                                       |
-| `radsToDegs`                 | `RadsToDegs`                                       |
-| `greatCircleDistance`        | `GreatCircleDistance* (3/3)`                       |
-| `getHexagonAreaAvg`          | `HexagonAreaAvg* (3/3)`                            |
-| `cellArea`                   | `CellArea* (3/3)`                                  |
-| `getHexagonEdgeLengthAvg`    | `HexagonEdgeLengthAvg* (2/2)`                      |
-| `exactEdgeLength`            | `EdgeLength* (3/3)`                                |
-| `getNumCells`                | `NumCells`                                         |
-| `getRes0Cells`               | `Res0Cells`                                        |
-| `getPentagons`               | `Pentagons`                                        |
-| `getResolution`              | `Resolution`                                       |
-| `getBaseCellNumber`          | `BaseCellNumber`, `Cell#BaseCellNumber`            |
-| `stringToH3`                 | `IndexFromString`, `Cell#UnmarshalText`            |
-| `h3ToString`                 | `IndexToString`, `Cell#String`, `Cell#MarshalText` |
-| `isValidCell`                | `Cell#IsValid`                                     |
-| `cellToParent`               | `Cell#Parent`, `Cell#ImmediateParent`              |
-| `cellToChildren`             | `Cell#Children` `Cell#ImmediateChildren`           |
-| `cellToCenterChild`          | `Cell#CenterChild`                                 |
-| `compactCells`               | `CompactCells`                                     |
-| `uncompactCells`             | `UncompactCells`                                   |
-| `isResClassIII`              | `Cell#IsResClassIII`                               |
-| `isPentagon`                 | `Cell#IsPentagon`                                  |
-| `getIcosahedronFaces`        | `Cell#IcosahedronFaces`                            |
-| `areNeighborCells`           | `Cell#IsNeighbor`                                  |
-| `cellsToDirectedEdge`        | `Cell#DirectedEdge`                                |
-| `isValidDirectedEdge`        | `DirectedEdge#IsValid`                             |
-| `getDirectedEdgeOrigin`      | `DirectedEdge#Origin`                              |
-| `getDirectedEdgeDestination` | `DirectedEdge#Destination`                         |
-| `directedEdgeToCells`        | `DirectedEdge#Cells`                               |
-| `originToDirectedEdges`      | `Cell#DirectedEdges`                               |
-| `directedEdgeToBoundary`     | `DirectedEdge#Boundary`                            |
-| `cellToVertex`               | `CellToVertex`                                     |
-| `cellToVertexes`             | `CellToVertexes`                                   |
-| `vertexToLatLng`             | `VertexToLatLng`                                   |
-| `isValidVertex`              | `IsValidVertex`                                    |
-| `gridDistance`               | `GridDistance`, `Cell#GridDistance`                |
-| `gridPathCells`              | `GridPath`, `Cell#GridPath`                        |
-| `cellToLocalIj`              | `CellToLocalIJ`                                    |
-| `localIjToCell`              | `LocalIJToCell`                                    |
+| C API                        | Go API                                                    |
+|------------------------------|-----------------------------------------------------------|
+| `latLngToCell`               | `LatLngToCell`, `LatLng#Cell`                             |
+| `cellToLatLng`               | `CellToLatLng`, `Cell#LatLng`                             |
+| `cellToBoundary`             | `CellToBoundary`, `Cell#Boundary`                         |
+| `gridDisk`                   | `GridDisk`, `Cell#GridDisk`                               |
+| `gridDisksUnsafe`            | `GridDisksUnsafe`                                         |
+| `gridDiskDistances`          | `GridDiskDistances`, `Cell#GridDiskDistances`             |
+| `gridDiskDistancesSafe`      | `GridDiskDistancesSafe`, `Cell#GridDiskDistancesSafe`     |
+| `gridDiskDistancesUnsafe`    | `GridDiskDistancesUnsafe`, `Cell#GridDiskDistancesUnsafe` |
+| `gridRingUnsafe`             | `GridRingUnsafe`, `Cell#GridRingUnsafe`                   |
+| `polygonToCells`             | `PolygonToCells`, `GeoPolygon#Cells`                      |
+| `cellsToMultiPolygon`        | `CellsToMultiPolygon`                                     |
+| `degsToRads`                 | `DegsToRads`                                              |
+| `radsToDegs`                 | `RadsToDegs`                                              |
+| `greatCircleDistance`        | `GreatCircleDistance* (3/3)`                              |
+| `getHexagonAreaAvg`          | `HexagonAreaAvg* (3/3)`                                   |
+| `cellArea`                   | `CellArea* (3/3)`                                         |
+| `getHexagonEdgeLengthAvg`    | `HexagonEdgeLengthAvg* (2/2)`                             |
+| `exactEdgeLength`            | `EdgeLength* (3/3)`                                       |
+| `getNumCells`                | `NumCells`                                                |
+| `getRes0Cells`               | `Res0Cells`                                               |
+| `getPentagons`               | `Pentagons`                                               |
+| `getResolution`              | `Resolution`                                              |
+| `getBaseCellNumber`          | `BaseCellNumber`, `Cell#BaseCellNumber`                   |
+| `stringToH3`                 | `IndexFromString`, `Cell#UnmarshalText`                   |
+| `h3ToString`                 | `IndexToString`, `Cell#String`, `Cell#MarshalText`        |
+| `isValidCell`                | `Cell#IsValid`                                            |
+| `cellToParent`               | `Cell#Parent`, `Cell#ImmediateParent`                     |
+| `cellToChildren`             | `Cell#Children` `Cell#ImmediateChildren`                  |
+| `cellToCenterChild`          | `Cell#CenterChild`                                        |
+| `compactCells`               | `CompactCells`                                            |
+| `uncompactCells`             | `UncompactCells`                                          |
+| `isResClassIII`              | `Cell#IsResClassIII`                                      |
+| `isPentagon`                 | `Cell#IsPentagon`                                         |
+| `getIcosahedronFaces`        | `Cell#IcosahedronFaces`                                   |
+| `areNeighborCells`           | `Cell#IsNeighbor`                                         |
+| `cellsToDirectedEdge`        | `Cell#DirectedEdge`                                       |
+| `isValidDirectedEdge`        | `DirectedEdge#IsValid`                                    |
+| `getDirectedEdgeOrigin`      | `DirectedEdge#Origin`                                     |
+| `getDirectedEdgeDestination` | `DirectedEdge#Destination`                                |
+| `directedEdgeToCells`        | `DirectedEdge#Cells`                                      |
+| `originToDirectedEdges`      | `Cell#DirectedEdges`                                      |
+| `directedEdgeToBoundary`     | `DirectedEdge#Boundary`                                   |
+| `cellToVertex`               | `CellToVertex`                                            |
+| `cellToVertexes`             | `CellToVertexes`                                          |
+| `vertexToLatLng`             | `VertexToLatLng`                                          |
+| `isValidVertex`              | `IsValidVertex`                                           |
+| `gridDistance`               | `GridDistance`, `Cell#GridDistance`                       |
+| `gridPathCells`              | `GridPath`, `Cell#GridPath`                               |
+| `cellToLocalIj`              | `CellToLocalIJ`                                           |
+| `localIjToCell`              | `LocalIJToCell`                                           |
 
 ## CGO
 

--- a/h3.go
+++ b/h3.go
@@ -247,7 +247,7 @@ func GridDisksUnsafe(origins []Cell, k int) ([][]Cell, error) {
 		inner := make([]C.H3Index, maxGridDiskSize(k))
 		errC := C.gridDiskUnsafe(C.H3Index(origins[i]), C.int(k), &inner[0])
 		if err := toErr(errC); err != nil {
-			return out, err
+			return nil, err
 		}
 		out[i] = cellsFromC(inner, true, false)
 	}

--- a/h3.go
+++ b/h3.go
@@ -230,7 +230,34 @@ func (c Cell) GridDisk(k int) ([]Cell, error) {
 	return GridDisk(c, k)
 }
 
+// GridDisksUnsafe produces cells within grid distance k of all provided origin
+// cells.
+//
+// k-ring 0 is defined as the origin cell, k-ring 1 is defined as k-ring 0 and
+// all neighboring cells, and so on.
+//
+// Outer slice is ordered in the same order origins were passed in. Inner slices
+// are in no particular order.
+//
+// This does not call through to the underlying C.gridDisksUnsafe implementation
+// as it is slightly easier to do so to avoid unnecessary type conversions.
+func GridDisksUnsafe(origins []Cell, k int) ([][]Cell, error) {
+	out := make([][]Cell, len(origins))
+	for i := range origins {
+		inner := make([]C.H3Index, maxGridDiskSize(k))
+		errC := C.gridDiskUnsafe(C.H3Index(origins[i]), C.int(k), &inner[0])
+		if err := toErr(errC); err != nil {
+			return out, err
+		}
+		out[i] = cellsFromC(inner, true, false)
+	}
+	return out, nil
+}
+
 // GridDiskDistances produces cells within grid distance k of the origin cell.
+// This method optimistically tries the faster GridDiskDistancesUnsafe first.
+// If a cell was a pentagon or was in the pentagon distortion area, it falls
+// back to GridDiskDistancesSafe.
 //
 // k-ring 0 is defined as the origin cell, k-ring 1 is defined as k-ring 0 and
 // all neighboring cells, and so on.
@@ -260,6 +287,9 @@ func GridDiskDistances(origin Cell, k int) ([][]Cell, error) {
 }
 
 // GridDiskDistances produces cells within grid distance k of the origin cell.
+// This method optimistically tries the faster GridDiskDistancesUnsafe first.
+// If a cell was a pentagon or was in the pentagon distortion area, it falls
+// back to GridDiskDistancesSafe.
 //
 // k-ring 0 is defined as the origin cell, k-ring 1 is defined as k-ring 0 and
 // all neighboring cells, and so on.
@@ -269,6 +299,94 @@ func GridDiskDistances(origin Cell, k int) ([][]Cell, error) {
 // happen when crossing a pentagon.
 func (c Cell) GridDiskDistances(k int) ([][]Cell, error) {
 	return GridDiskDistances(c, k)
+}
+
+// GridDiskDistancesUnsafe produces cells within grid distance k of the origin cell.
+// Output behavior is undefined when one of the cells returned by this
+// function is a pentagon or is in the pentagon distortion area.
+//
+// k-ring 0 is defined as the origin cell, k-ring 1 is defined as k-ring 0 and
+// all neighboring cells, and so on.
+//
+// Outer slice is ordered from origin outwards. Inner slices are in no
+// particular order. Elements of the output array may be left zero, as can
+// happen when crossing a pentagon.
+func GridDiskDistancesUnsafe(origin Cell, k int) ([][]Cell, error) {
+	rsz := maxGridDiskSize(k)
+	outHexes := make([]C.H3Index, rsz)
+	outDists := make([]C.int, rsz)
+
+	if err := toErr(C.gridDiskDistancesUnsafe(C.H3Index(origin), C.int(k), &outHexes[0], &outDists[0])); err != nil {
+		return nil, err
+	}
+
+	ret := make([][]Cell, k+1)
+	for i := 0; i <= k; i++ {
+		ret[i] = make([]Cell, 0, ringSize(i))
+	}
+
+	for i, d := range outDists {
+		ret[d] = append(ret[d], Cell(outHexes[i]))
+	}
+
+	return ret, nil
+}
+
+// GridDiskDistancesUnsafe produces cells within grid distance k of the origin cell.
+// Output behavior is undefined when one of the cells returned by this
+// function is a pentagon or is in the pentagon distortion area.
+//
+// k-ring 0 is defined as the origin cell, k-ring 1 is defined as k-ring 0 and
+// all neighboring cells, and so on.
+//
+// Outer slice is ordered from origin outwards. Inner slices are in no
+// particular order. Elements of the output array may be left zero, as can
+// happen when crossing a pentagon.
+func (c Cell) GridDiskDistancesUnsafe(k int) ([][]Cell, error) {
+	return GridDiskDistancesUnsafe(c, k)
+}
+
+// GridDiskDistancesSafe produces cells within grid distance k of the origin cell.
+// This is the safe, but slow version of GridDiskDistances.
+//
+// k-ring 0 is defined as the origin cell, k-ring 1 is defined as k-ring 0 and
+// all neighboring cells, and so on.
+//
+// Outer slice is ordered from origin outwards. Inner slices are in no
+// particular order. Elements of the output array may be left zero, as can
+// happen when crossing a pentagon.
+func GridDiskDistancesSafe(origin Cell, k int) ([][]Cell, error) {
+	rsz := maxGridDiskSize(k)
+	outHexes := make([]C.H3Index, rsz)
+	outDists := make([]C.int, rsz)
+
+	if err := toErr(C.gridDiskDistancesSafe(C.H3Index(origin), C.int(k), &outHexes[0], &outDists[0])); err != nil {
+		return nil, err
+	}
+
+	ret := make([][]Cell, k+1)
+	for i := 0; i <= k; i++ {
+		ret[i] = make([]Cell, 0, ringSize(i))
+	}
+
+	for i, d := range outDists {
+		ret[d] = append(ret[d], Cell(outHexes[i]))
+	}
+
+	return ret, nil
+}
+
+// GridDiskDistancesSafe produces cells within grid distance k of the origin cell.
+// This is the safe, but slow version of GridDiskDistances.
+//
+// k-ring 0 is defined as the origin cell, k-ring 1 is defined as k-ring 0 and
+// all neighboring cells, and so on.
+//
+// Outer slice is ordered from origin outwards. Inner slices are in no
+// particular order. Elements of the output array may be left zero, as can
+// happen when crossing a pentagon.
+func (c Cell) GridDiskDistancesSafe(k int) ([][]Cell, error) {
+	return GridDiskDistancesSafe(c, k)
 }
 
 // GridRing produces the "hollow" ring of cells at exactly grid distance k from the origin cell.

--- a/h3.go
+++ b/h3.go
@@ -243,8 +243,9 @@ func (c Cell) GridDisk(k int) ([]Cell, error) {
 // as it is slightly easier to do so to avoid unnecessary type conversions.
 func GridDisksUnsafe(origins []Cell, k int) ([][]Cell, error) {
 	out := make([][]Cell, len(origins))
+	gridDiskSize := maxGridDiskSize(k)
 	for i := range origins {
-		inner := make([]C.H3Index, maxGridDiskSize(k))
+		inner := make([]C.H3Index, gridDiskSize)
 		errC := C.gridDiskUnsafe(C.H3Index(origins[i]), C.int(k), &inner[0])
 		if err := toErr(errC); err != nil {
 			return nil, err


### PR DESCRIPTION
Implements remaining bindings for C library functions.

This includes:
- GridDisksUnsafe
- GridDiskDistancesUnsafe
- GridDiskDistancesSafe

which are listed in the API Reference[0].

- 0: https://h3geo.org/docs/api/traversal