### PR TITLE
feat: Convert directly between C and Go arrays

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -29,27 +29,33 @@ func BenchmarkFromString(b *testing.B) {
 	}
 }
 
-func BenchmarkToGeoRes15(b *testing.B) {
+func BenchmarkCellToLatLng(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		geo, _ = CellToLatLng(cell)
 	}
 }
 
-func BenchmarkFromGeoRes15(b *testing.B) {
+func BenchmarkLatLngToCell(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		cell, _ = LatLngToCell(geo, 15)
 	}
 }
 
-func BenchmarkToGeoBndryRes15(b *testing.B) {
+func BenchmarkCellToBoundary(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		geoBndry, _ = CellToBoundary(cell)
 	}
 }
 
-func BenchmarkHexRange(b *testing.B) {
+func BenchmarkGridDisk(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		cells, _ = cell.GridDisk(10)
+	}
+}
+
+func BenchmarkGridRing(b *testing.B) {
+	for range b.N {
+		cells, _ = cell.GridRing(10)
 	}
 }
 

--- a/h3.go
+++ b/h3.go
@@ -1057,18 +1057,14 @@ func intPow(n, m int) int {
 }
 
 func cellsFromC(chs []C.H3Index, prune, refit bool) []Cell {
-	// OPT: This could be more efficient if we unsafely cast the C array to a
-	// []H3Index.
-	out := make([]Cell, 0, len(chs))
-
-	for i := range chs {
-		if prune && chs[i] <= 0 {
+	in := unsafe.Slice((*Cell)(unsafe.Pointer(&chs[0])), len(chs))
+	out := in[:0]
+	for i := range in {
+		if prune && in[i] <= 0 {
 			continue
 		}
-
-		out = append(out, Cell(chs[i]))
+		out = append(out, in[i])
 	}
-
 	if refit {
 		// Some algorithms require a maximum sized array, but only use a subset
 		// of the memory.  refit sizes the slice to the last non-empty element.
@@ -1078,7 +1074,6 @@ func cellsFromC(chs []C.H3Index, prune, refit bool) []Cell {
 			}
 		}
 	}
-
 	return out
 }
 
@@ -1097,14 +1092,7 @@ func edgesFromC(chs []C.H3Index) []DirectedEdge {
 }
 
 func cellsToC(chs []Cell) []C.H3Index {
-	// OPT: This could be more efficient if we unsafely cast the array to a
-	// []C.H3Index.
-	out := make([]C.H3Index, len(chs))
-	for i := range chs {
-		out[i] = C.H3Index(chs[i])
-	}
-
-	return out
+	return unsafe.Slice((*C.H3Index)(unsafe.Pointer(&chs[0])), len(chs))
 }
 
 func intsFromC(chs []C.int) []int {


### PR DESCRIPTION
Save a few allocations by converting directly between C and Go arrays.

```
goos: darwin
goarch: arm64
pkg: github.com/uber/h3-go/v4
cpu: Apple M3 Max
BenchmarkToString-16          	62702066	        17.13 ns/op	      16 B/op	       1 allocs/op
BenchmarkFromString-16        	42018031	        27.86 ns/op	       0 B/op	       0 allocs/op
BenchmarkCellToLatLng-16      	 6184140	       192.3 ns/op	      16 B/op	       1 allocs/op
BenchmarkLatLngToCell-16      	 3529909	       340.2 ns/op	      24 B/op	       2 allocs/op
BenchmarkCellToBoundary-16    	 1628898	       737.0 ns/op	     336 B/op	       2 allocs/op
BenchmarkGridDisk-16          	  331419	      3601 ns/op	    5376 B/op	       2 allocs/op
BenchmarkGridRing-16          	 1606585	       746.3 ns/op	     960 B/op	       2 allocs/op
PASS
```

```
goos: darwin
goarch: arm64
pkg: github.com/uber/h3-go/v4
cpu: Apple M3 Max
BenchmarkToString-16          	70314662	        16.96 ns/op	      16 B/op	       1 allocs/op
BenchmarkFromString-16        	40283664	        29.25 ns/op	       0 B/op	       0 allocs/op
BenchmarkCellToLatLng-16      	 6232748	       191.7 ns/op	      16 B/op	       1 allocs/op
BenchmarkLatLngToCell-16      	 3487287	       339.9 ns/op	      24 B/op	       2 allocs/op
BenchmarkCellToBoundary-16    	 1642731	       729.9 ns/op	     336 B/op	       2 allocs/op
BenchmarkGridDisk-16          	  342846	      3496 ns/op	    2688 B/op	       1 allocs/op
BenchmarkGridRing-16          	 1686889	       712.3 ns/op	     480 B/op	       1 allocs/op
PASS
````

```
GridDisk-16          5.38kB ± 0%    2.69kB ± 0%   ~     (p=1.000 n=1+1)
GridRing-16            960B ± 0%      480B ± 0%   ~     (p=1.000 n=1+1)

GridDisk-16            2.00 ± 0%      1.00 ± 0%   ~     (p=1.000 n=1+1)
GridRing-16            2.00 ± 0%      1.00 ± 0%   ~     (p=1.000 n=1+1)
```
The delta here though is about even though.