### PR TITLE
feat: introduce CellFrom/ToString

### DIFF
--- a/h3.go
+++ b/h3.go
@@ -740,7 +740,7 @@ func (c Cell) BaseCellNumber() int {
 	return BaseCellNumber(c)
 }
 
-// IndexFromString returns a Cell from a string. Should call c.IsValid() to check
+// IndexFromString returns an uint64 from a string. Should call c.IsValid() to check
 // if the Cell is valid before using it.
 func IndexFromString(s string) uint64 {
 	if len(s) > 2 && strings.ToLower(s[:2]) == "0x" {
@@ -751,15 +751,25 @@ func IndexFromString(s string) uint64 {
 	return c
 }
 
-// IndexToString returns a Cell from a string. Should call c.IsValid() to check
-// if the Cell is valid before using it.
+// IndexToString returns a string from a Cell.
 func IndexToString(i uint64) string {
 	return strconv.FormatUint(i, base16)
 }
 
+// CellFromString returns a Cell from a string. Should call c.IsValid() to check
+// if the Cell is valid before using it.
+func CellFromString(s string) Cell {
+	return Cell(IndexFromString(s))
+}
+
+// CellToString returns a string from a Cell.
+func CellToString(c Cell) string {
+	return IndexToString(uint64(c))
+}
+
 // String returns the string representation of the H3Index h.
 func (c Cell) String() string {
-	return IndexToString(uint64(c))
+	return CellToString(c)
 }
 
 // MarshalText implements the encoding.TextMarshaler interface.

--- a/h3_test.go
+++ b/h3_test.go
@@ -658,6 +658,9 @@ func TestStrings(t *testing.T) {
 		t.Parallel()
 		i := IndexFromString("oops")
 		assertEqual(t, 0, i)
+
+		c := CellFromString("oops")
+		assertEqual(t, 0, c)
 	})
 
 	t.Run("good string round trip", func(t *testing.T) {
@@ -666,6 +669,9 @@ func TestStrings(t *testing.T) {
 
 		//nolint:gosec // IndexFromString returns uint64 and fixing that to detect integer overflows will break package API. Let's skip it for now.
 		assertEqual(t, validCell, Cell(i))
+
+		c := CellFromString(validCell.String())
+		assertEqual(t, validCell, c)
 	})
 
 	t.Run("no 0x prefix", func(t *testing.T) {


### PR DESCRIPTION
The preexisting `IndexFromString` and `IndexToString` utils aren't
strongly typed with `Cell`s which requires casting between `uint64` <>
`Cell` to use them.

Introduce `CellFromString` and `CellToString` functions for a quality
of life improvement.