### PR TITLE
feat: breaking: introduce Vertex typedef

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,6 +58,13 @@ linters:
           list-mode: lax
           allow:
             - "github.com/uber/h3-go/v4"
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - dupl
+          - fieldalignment
+          - gosec
 
 formatters:
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -63,8 +63,8 @@ linters:
       - path: _test\.go
         linters:
           - dupl
-          - fieldalignment
           - gosec
+          - govet
 
 formatters:
   enable:

--- a/bench_test.go
+++ b/bench_test.go
@@ -26,7 +26,6 @@ func BenchmarkToString(b *testing.B) {
 
 func BenchmarkFromString(b *testing.B) {
 	for range b.N {
-		//nolint:gosec // IndexFromString returns uint64 and fixing that to detect integer overflows will break package API. Let's skip it for now.
 		cell = Cell(IndexFromString("850dab63fffffff"))
 	}
 }

--- a/h3_test.go
+++ b/h3_test.go
@@ -668,7 +668,6 @@ func TestStrings(t *testing.T) {
 		t.Parallel()
 		i := IndexFromString(validCell.String())
 
-		//nolint:gosec // IndexFromString returns uint64 and fixing that to detect integer overflows will break package API. Let's skip it for now.
 		assertEqual(t, validCell, Cell(i))
 
 		c := CellFromString(validCell.String())
@@ -940,8 +939,8 @@ func TestGridPath(t *testing.T) {
 	t.Run("err/pentagon", func(t *testing.T) {
 		t.Parallel()
 
-		start := Cell(IndexFromString("0x820807fffffffff")) //nolint:gosec // test
-		end := Cell(IndexFromString("0x8208e7fffffffff"))   //nolint:gosec // test
+		start := Cell(IndexFromString("0x820807fffffffff"))
+		end := Cell(IndexFromString("0x8208e7fffffffff"))
 
 		_, err := GridPath(start, end)
 		assertErr(t, err)
@@ -949,7 +948,7 @@ func TestGridPath(t *testing.T) {
 	})
 }
 
-func TestHexAreaKm2(t *testing.T) { //nolint:dupl // // it's ok to have duplication in tests.
+func TestHexAreaKm2(t *testing.T) {
 	t.Parallel()
 
 	t.Run("min resolution", func(t *testing.T) {
@@ -981,7 +980,7 @@ func TestHexAreaKm2(t *testing.T) { //nolint:dupl // // it's ok to have duplicat
 	})
 }
 
-func TestHexAreaM2(t *testing.T) { //nolint:dupl // // it's ok to have duplication in tests.
+func TestHexAreaM2(t *testing.T) {
 	t.Parallel()
 
 	t.Run("min resolution", func(t *testing.T) {


### PR DESCRIPTION
With the existing implementation, `Vertex`es don't have a separate typedef. This is inconsistent with the `DirectedEdge` implementation which has its own typedef. As vertex mode[0] is a distinct mode, let's update these methods with its own typedef.

This is a breaking change.

- 0: https://h3geo.org/docs/library/index/vertex