### PR TITLE
feat: add LatLngToCellsBatch for reduced cgo overhead

### DIFF
--- a/h3.go
+++ b/h3.go
@@ -27,6 +27,23 @@ package h3
 #include <h3_h3Index.h>
 #include <h3_polygon.h>
 #include <h3_polyfill.h>
+
+// latLngToCellBatch converts n LatLng points to cells at a single resolution.
+// Returns 0 on success, or the H3 error code of the first failing point
+// (with failIdx set to its index).
+static uint32_t latLngToCellBatch(
+    const LatLng *lls, int n, int res, H3Index *out, int *failIdx
+) {
+    for (int i = 0; i < n; i++) {
+        uint32_t err = latLngToCell(&lls[i], res, &out[i]);
+        if (err != 0) {
+            *failIdx = i;
+            return err;
+        }
+    }
+    *failIdx = -1;
+    return 0;
+}
 */
 import "C"
 
@@ -237,6 +254,53 @@ func LatLngToCell(latLng LatLng, resolution int) (Cell, error) {
 // Cell returns the Cell at resolution for a geographic coordinate.
 func (g LatLng) Cell(resolution int) (Cell, error) {
 	return LatLngToCell(g, resolution)
+}
+
+// LatLngToCellsBatch computes cells for multiple points at a single resolution
+// in one cgo call, reducing per-call cgo transition overhead for bulk workloads.
+//
+// Returns a slice of Cells corresponding to each input LatLng. If any single
+// point fails to convert, the function returns an error indicating the first
+// failing index.
+func LatLngToCellsBatch(lls []LatLng, resolution int) ([]Cell, error) {
+	n := len(lls)
+	if n == 0 {
+		return nil, nil
+	}
+
+	if resolution < 0 || resolution > MaxResolution {
+		return nil, ErrResDomain
+	}
+
+	// Pre-convert all Go LatLngs to C LatLngs.
+	cLLs := make([]C.LatLng, n)
+	for i, ll := range lls {
+		cLLs[i] = ll.toC()
+	}
+
+	// Allocate output buffer.
+	cCells := make([]C.H3Index, n)
+
+	// Single cgo transition: the C helper loops over all points internally.
+	var failIdx C.int
+	errC := C.latLngToCellBatch(
+		&cLLs[0],
+		C.int(n),
+		C.int(resolution),
+		&cCells[0],
+		&failIdx,
+	)
+	if err := toErr(errC); err != nil {
+		return nil, fmt.Errorf("index %d: %w", int(failIdx), err)
+	}
+
+	// Convert C output to Go slice.
+	cells := make([]Cell, n)
+	for i, c := range cCells {
+		cells[i] = Cell(c)
+	}
+
+	return cells, nil
 }
 
 // CellToLatLng returns the geographic centerpoint of a Cell.

--- a/h3_bench_test.go
+++ b/h3_bench_test.go
@@ -33,3 +33,34 @@ func BenchmarkNumCells(b *testing.B) {
 		})
 	}
 }
+
+var cellSink []Cell
+
+func BenchmarkLatLngToCellsBatch(b *testing.B) {
+	sizes := []int{64, 1024, 16384}
+	for _, n := range sizes {
+		lls := make([]LatLng, n)
+		for i := range lls {
+			lls[i] = NewLatLng(
+				float64(i%180)-90.0,
+				float64(i%360)-180.0,
+			)
+		}
+		b.Run("batch_"+strconv.Itoa(n), func(b *testing.B) {
+			var cells []Cell
+			for b.Loop() {
+				cells, _ = LatLngToCellsBatch(lls, 6)
+			}
+			cellSink = cells
+		})
+		b.Run("percall_"+strconv.Itoa(n), func(b *testing.B) {
+			cells := make([]Cell, n)
+			for b.Loop() {
+				for i, ll := range lls {
+					cells[i], _ = LatLngToCell(ll, 6)
+				}
+			}
+			cellSink = cells
+		})
+	}
+}

--- a/h3_test.go
+++ b/h3_test.go
@@ -121,6 +121,46 @@ func TestLatLngToCell(t *testing.T) {
 	assertErrIs(t, err, ErrResolutionDomain)
 }
 
+func TestLatLngToCellsBatch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single point matches LatLngToCell", func(t *testing.T) {
+		t.Parallel()
+		cells, err := LatLngToCellsBatch([]LatLng{validLatLng1}, 5)
+		assertNoErr(t, err)
+		assertEqual(t, 1, len(cells))
+		assertEqual(t, validCell, cells[0])
+	})
+
+	t.Run("multiple points", func(t *testing.T) {
+		t.Parallel()
+		lls := []LatLng{validLatLng1, validLatLng2, NewLatLng(0, 0)}
+		cells, err := LatLngToCellsBatch(lls, 5)
+		assertNoErr(t, err)
+		assertEqual(t, 3, len(cells))
+
+		// Verify each result matches individual calls.
+		for i, ll := range lls {
+			expected, err := LatLngToCell(ll, 5)
+			assertNoErr(t, err)
+			assertEqual(t, expected, cells[i])
+		}
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		t.Parallel()
+		cells, err := LatLngToCellsBatch(nil, 5)
+		assertNoErr(t, err)
+		assertEqual(t, 0, len(cells))
+	})
+
+	t.Run("invalid resolution", func(t *testing.T) {
+		t.Parallel()
+		_, err := LatLngToCellsBatch([]LatLng{validLatLng1}, MaxResolution+1)
+		assertErr(t, err)
+	})
+}
+
 func TestCellToLatLng(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Implements the batched `LatLngToCellsBatch` API proposed in #113 to reduce cgo transition overhead for bulk workloads.

Closes #113

## API

```go
// Compute cells for n points at a single resolution. One cgo transition.
func LatLngToCellsBatch(lls []LatLng, resolution int) ([]Cell, error)
```

## Implementation

A static C helper function `latLngToCellBatch` is added to the cgo preamble. It loops over all input points on the C side, calling `latLngToCell` per point within a single cgo boundary crossing. This eliminates the per-call goroutine state save/restore overhead that dominates tight loops (as profiled in #113: ~21% CPU in `runtime.cgocall` vs ~4% in actual H3 computation).

The Go side:
1. Validates inputs (empty slice, resolution bounds)
2. Pre-converts all `LatLng` to `C.LatLng` 
3. Makes a single cgo call to the batch helper
4. Reports errors with the failing index

## Testing

- Unit tests: single point consistency with `LatLngToCell`, multiple points, empty input, invalid resolution
- Benchmark: comparative bench at 64/1024/16384 points (batch vs per-call)

**Note**: Go toolchain was not available in my build environment, so CI will be the first full verification. The implementation follows the exact patterns used by existing functions in the codebase.

## Changes

- `h3.go` — C batch helper + `LatLngToCellsBatch` function
- `h3_test.go` — unit tests
- `h3_bench_test.go` — comparative benchmarks