### PR TITLE
feat: implement reverseDirectedEdge

### DIFF
--- a/h3.go
+++ b/h3.go
@@ -988,6 +988,13 @@ func (e DirectedEdge) Destination() (Cell, error) {
 	return Cell(out), toErr(errC)
 }
 
+// Reverse returns the directed edge from destination to origin cell.
+func (e DirectedEdge) Reverse() (DirectedEdge, error) {
+	var out C.H3Index
+	errC := C.reverseDirectedEdge(C.H3Index(e), &out)
+	return DirectedEdge(out), toErr(errC)
+}
+
 // Cells returns the origin and destination cells in that order.
 func (e DirectedEdge) Cells() ([]Cell, error) {
 	out := make([]C.H3Index, numEdgeCells)

--- a/h3_test.go
+++ b/h3_test.go
@@ -663,6 +663,41 @@ func TestDirectedEdge(t *testing.T) {
 	})
 }
 
+func TestDirectedEdge_Reverse(t *testing.T) {
+	t.Parallel()
+
+	origin := validDiskDist3_1[1][0]
+	edges, err := origin.DirectedEdges()
+	assertNoErr(t, err)
+
+	destination, err := edges[0].Destination()
+	assertNoErr(t, err)
+
+	edge, err := origin.DirectedEdge(destination)
+	assertNoErr(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		reversed, err := edge.Reverse()
+		assertNoErr(t, err)
+
+		revOrigin, err := reversed.Origin()
+		assertNoErr(t, err)
+		revDestination, err := reversed.Destination()
+		assertNoErr(t, err)
+
+		assertEqual(t, destination, revOrigin)
+		assertEqual(t, origin, revDestination)
+	})
+
+	t.Run("err", func(t *testing.T) {
+		t.Parallel()
+		_, err := DirectedEdge(-1).Reverse()
+		assertErr(t, err)
+		assertErrIs(t, err, ErrDirectedEdgeInvalid)
+	})
+}
+
 func TestStrings(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Wraps the new reverseDirectedEdge API as DirectedEdge.Reverse(), returning the edge from destination to origin.