### PR TITLE
feat: add LatLngToCellBatch for lower cgo overhead

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -54,7 +54,7 @@ func BenchmarkLatLngToCell(b *testing.B) {
 	}
 }
 
-func BenchmarkLatLngToCellsBatch(b *testing.B) {
+func BenchmarkLatLngToCellBatch(b *testing.B) {
 	for _, n := range []int{1, 64, 1024, 16384, 1_000_000, 10_000_000} {
 		lls := make([]LatLng, n)
 		for i := range lls {
@@ -72,7 +72,7 @@ func BenchmarkLatLngToCellsBatch(b *testing.B) {
 // Baseline: same workload via the per-call LatLngToCell in a Go loop,
 // so reviewers can confirm the speedup at each batch size by comparing
 // matching sub-benchmark names with benchstat.
-func BenchmarkLatLngToCellsBaseline(b *testing.B) {
+func BenchmarkLatLngToCellBaseline(b *testing.B) {
 	for _, n := range []int{1, 64, 1024, 16384, 1_000_000, 10_000_000} {
 		lls := make([]LatLng, n)
 		for i := range lls {

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,6 +1,7 @@
 package h3
 
 import (
+	"strconv"
 	"testing"
 )
 
@@ -50,6 +51,42 @@ func BenchmarkCellToLatLng(b *testing.B) {
 func BenchmarkLatLngToCell(b *testing.B) {
 	for range b.N {
 		cell, _ = LatLngToCell(geo, 15)
+	}
+}
+
+func BenchmarkLatLngToCellsBatch(b *testing.B) {
+	for _, n := range []int{1, 64, 1024, 16384, 1_000_000, 10_000_000} {
+		lls := make([]LatLng, n)
+		for i := range lls {
+			lls[i] = LatLng{Lat: 37.7749 + float64(i)*1e-6, Lng: -122.4194}
+		}
+
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for b.Loop() {
+				cells, _ := LatLngToCellsBatch(lls, 9)
+				sink = int(cells[0])
+			}
+		})
+	}
+}
+
+// Baseline: same workload via the per-call LatLngToCell in a Go loop,
+// so reviewers can confirm the speedup at each batch size by comparing
+// matching sub-benchmark names with benchstat.
+func BenchmarkLatLngToCellsBaseline(b *testing.B) {
+	for _, n := range []int{1, 64, 1024, 16384, 1_000_000, 10_000_000} {
+		lls := make([]LatLng, n)
+		for i := range lls {
+			lls[i] = LatLng{Lat: 37.7749 + float64(i)*1e-6, Lng: -122.4194}
+		}
+
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for range b.N {
+				for _, ll := range lls {
+					cell, _ = LatLngToCell(ll, 9)
+				}
+			}
+		})
 	}
 }
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -63,7 +63,7 @@ func BenchmarkLatLngToCellBatch(b *testing.B) {
 
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			for b.Loop() {
-				cells, _ = LatLngToCellsBatch(lls, 15)
+				cells, _ = LatLngToCellBatch(lls, 15)
 			}
 		})
 	}

--- a/bench_test.go
+++ b/bench_test.go
@@ -58,13 +58,12 @@ func BenchmarkLatLngToCellsBatch(b *testing.B) {
 	for _, n := range []int{1, 64, 1024, 16384, 1_000_000, 10_000_000} {
 		lls := make([]LatLng, n)
 		for i := range lls {
-			lls[i] = LatLng{Lat: 37.7749 + float64(i)*1e-6, Lng: -122.4194}
+			lls[i] = geo
 		}
 
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			for b.Loop() {
-				cells, _ := LatLngToCellsBatch(lls, 9)
-				sink = int(cells[0])
+				cells, _ = LatLngToCellsBatch(lls, 15)
 			}
 		})
 	}
@@ -77,13 +76,13 @@ func BenchmarkLatLngToCellsBaseline(b *testing.B) {
 	for _, n := range []int{1, 64, 1024, 16384, 1_000_000, 10_000_000} {
 		lls := make([]LatLng, n)
 		for i := range lls {
-			lls[i] = LatLng{Lat: 37.7749 + float64(i)*1e-6, Lng: -122.4194}
+			lls[i] = geo
 		}
 
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
-			for range b.N {
+			for b.Loop() {
 				for _, ll := range lls {
-					cell, _ = LatLngToCell(ll, 9)
+					cell, _ = LatLngToCell(ll, 15)
 				}
 			}
 		})

--- a/h3.go
+++ b/h3.go
@@ -27,6 +27,7 @@ package h3
 #include <h3_h3Index.h>
 #include <h3_polygon.h>
 #include <h3_polyfill.h>
+#include <h3_latLngBatch.h>
 */
 import "C"
 
@@ -232,6 +233,41 @@ func LatLngToCell(latLng LatLng, resolution int) (Cell, error) {
 	errC := C.latLngToCell(&cLatLng, C.int(resolution), &i)
 
 	return Cell(i), toErr(errC)
+}
+
+// LatLngToCellsBatch resolves a slice of LatLng to H3 cells at the
+// provided resolution with one cgo transition for the whole batch.
+//
+// Equivalent to calling LatLngToCell once per element, but amortizes
+// the per-call cgo overhead.
+//
+// Output cell ordering matches the input ordering. Returns nil and
+// the first H3 error encountered if any LatLng fails resolution;
+// partial results are not returned.
+func LatLngToCellsBatch(lls []LatLng, resolution int) ([]Cell, error) {
+	n := len(lls)
+	if n == 0 {
+		return nil, nil
+	}
+	cLLs := make([]C.LatLng, n)
+	for i, ll := range lls {
+		cLLs[i] = ll.toC()
+	}
+	cOut := make([]C.H3Index, n)
+	errC := C.latLngToCellsBatch(
+		&cLLs[0],
+		C.size_t(n),
+		C.int(resolution),
+		&cOut[0],
+	)
+	if err := toErr(errC); err != nil {
+		return nil, err
+	}
+	out := make([]Cell, n)
+	for i := range cOut {
+		out[i] = Cell(cOut[i])
+	}
+	return out, nil
 }
 
 // Cell returns the Cell at resolution for a geographic coordinate.

--- a/h3.go
+++ b/h3.go
@@ -235,7 +235,7 @@ func LatLngToCell(latLng LatLng, resolution int) (Cell, error) {
 	return Cell(i), toErr(errC)
 }
 
-// LatLngToCellsBatch resolves a slice of LatLng to H3 cells at the
+// LatLngToCellBatch resolves a slice of LatLng to H3 cells at the
 // provided resolution with one cgo transition for the whole batch.
 //
 // Equivalent to calling LatLngToCell once per element, but amortizes
@@ -244,7 +244,7 @@ func LatLngToCell(latLng LatLng, resolution int) (Cell, error) {
 // Output cell ordering matches the input ordering. Returns nil and
 // the first H3 error encountered if any LatLng fails resolution;
 // partial results are not returned.
-func LatLngToCellsBatch(lls []LatLng, resolution int) ([]Cell, error) {
+func LatLngToCellBatch(lls []LatLng, resolution int) ([]Cell, error) {
 	n := len(lls)
 	if n == 0 {
 		return nil, nil
@@ -254,7 +254,7 @@ func LatLngToCellsBatch(lls []LatLng, resolution int) ([]Cell, error) {
 		cLLs[i] = ll.toC()
 	}
 	cOut := make([]C.H3Index, n)
-	errC := C.latLngToCellsBatch(
+	errC := C.latLngToCellBatch(
 		&cLLs[0],
 		C.size_t(n),
 		C.int(resolution),

--- a/h3_latLngBatch.c
+++ b/h3_latLngBatch.c
@@ -1,14 +1,16 @@
 #include <h3_latLngBatch.h>
 
-H3Error latLngToCellsBatch(
-    const LatLng* lls,
+H3Error latLngToCellBatch(
+    const LatLng *lls,
     size_t n,
     int res,
-    H3Index* out
-) {
-    for (size_t i = 0; i < n; i++) {
+    H3Index *out)
+{
+    for (size_t i = 0; i < n; i++)
+    {
         H3Error err = latLngToCell(&lls[i], res, &out[i]);
-        if (err != E_SUCCESS) {
+        if (err != E_SUCCESS)
+        {
             return err;
         }
     }

--- a/h3_latLngBatch.c
+++ b/h3_latLngBatch.c
@@ -1,0 +1,16 @@
+#include <h3_latLngBatch.h>
+
+H3Error latLngToCellsBatch(
+    const LatLng* lls,
+    size_t n,
+    int res,
+    H3Index* out
+) {
+    for (size_t i = 0; i < n; i++) {
+        H3Error err = latLngToCell(&lls[i], res, &out[i]);
+        if (err != E_SUCCESS) {
+            return err;
+        }
+    }
+    return E_SUCCESS;
+}

--- a/h3_latLngBatch.h
+++ b/h3_latLngBatch.h
@@ -1,0 +1,36 @@
+// LatLng Batch helpers maintained by h3-go on top of the cloned H3 core.
+// Lives here so we can ship batched/amortized variants of single-shot
+// APIs without modifying the upsteam C library. Each function takes
+// input already in H3-native form (e.g. LatLng in radians), matching
+// the wire convention the existing Go bindings use after toC().
+//
+// If H3 core later exposes equivalents, the Go wrappers can be
+// re-pointed at the core symbols and these can be deleted.
+
+#ifndef H3_EXT_H
+#define H3_EXT_H
+
+#include <h3_h3api.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// latLngToCellsBatch resolved n LatLng inputs (already in radians) to
+// H3 cells at a single resolution. Output buffer must be sized n by
+// the caller. Returns E_SUCCESS on success, or the first H3Error
+// encountered (and stops). Output for rows past the failing index is
+// undefined.
+H3Error latLngToCellsBatch(
+    const LatLng* lls,
+    size_t n,
+    int res,
+    H3Index* out
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // H3_LAT_LNG_BATCH_H

--- a/h3_latLngBatch.h
+++ b/h3_latLngBatch.h
@@ -14,20 +14,20 @@
 #include <stddef.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-// latLngToCellsBatch resolved n LatLng inputs (already in radians) to
-// H3 cells at a single resolution. Output buffer must be sized n by
-// the caller. Returns E_SUCCESS on success, or the first H3Error
-// encountered (and stops). Output for rows past the failing index is
-// undefined.
-H3Error latLngToCellsBatch(
-    const LatLng* lls,
-    size_t n,
-    int res,
-    H3Index* out
-);
+    // latLngToCellBatch resolved n LatLng inputs (already in radians) to
+    // H3 cells at a single resolution. Output buffer must be sized n by
+    // the caller. Returns E_SUCCESS on success, or the first H3Error
+    // encountered (and stops). Output for rows past the failing index is
+    // undefined.
+    H3Error latLngToCellBatch(
+        const LatLng *lls,
+        size_t n,
+        int res,
+        H3Index *out);
 
 #ifdef __cplusplus
 }

--- a/h3_test.go
+++ b/h3_test.go
@@ -121,6 +121,55 @@ func TestLatLngToCell(t *testing.T) {
 	assertErrIs(t, err, ErrResolutionDomain)
 }
 
+func TestLatLngToCellsBatch(t *testing.T) {
+	t.Parallel()
+	t.Run("matches per-call result across resolutions", func(t *testing.T) {
+		t.Parallel()
+
+		lls := []LatLng{validLatLng1, validLatLng2}
+		for res := 0; res <= MaxResolution; res++ {
+			want := make([]Cell, len(lls))
+			for i, ll := range lls {
+				c, err := LatLngToCell(ll, res)
+				assertNoErr(t, err)
+				want[i] = c
+			}
+			got, err := LatLngToCellsBatch(lls, res)
+			assertNoErr(t, err)
+			assertEqual(t, len(want), len(got))
+
+			for i := range got {
+				assertEqual(t, want[i], got[i])
+			}
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+
+		cells, err := LatLngToCellsBatch(nil, 9)
+		assertNil(t, cells)
+		assertNil(t, err)
+	})
+
+	t.Run("single element", func(t *testing.T) {
+		t.Parallel()
+
+		cells, err := LatLngToCellsBatch([]LatLng{validLatLng1}, 5)
+		assertNoErr(t, err)
+		assertEqual(t, 1, len(cells))
+		assertEqual(t, validCell, cells[0])
+	})
+
+	t.Run("invalid resolution surfaces error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := LatLngToCellsBatch([]LatLng{validLatLng1}, MaxResolution+1)
+		assertErr(t, err)
+		assertErrIs(t, err, ErrResolutionDomain)
+	})
+}
+
 func TestCellToLatLng(t *testing.T) {
 	t.Parallel()
 

--- a/h3_test.go
+++ b/h3_test.go
@@ -121,7 +121,7 @@ func TestLatLngToCell(t *testing.T) {
 	assertErrIs(t, err, ErrResolutionDomain)
 }
 
-func TestLatLngToCellsBatch(t *testing.T) {
+func TestLatLngToCellBatch(t *testing.T) {
 	t.Parallel()
 	t.Run("matches per-call result across resolutions", func(t *testing.T) {
 		t.Parallel()
@@ -134,7 +134,7 @@ func TestLatLngToCellsBatch(t *testing.T) {
 				assertNoErr(t, err)
 				want[i] = c
 			}
-			got, err := LatLngToCellsBatch(lls, res)
+			got, err := LatLngToCellBatch(lls, res)
 			assertNoErr(t, err)
 			assertEqual(t, len(want), len(got))
 
@@ -147,7 +147,7 @@ func TestLatLngToCellsBatch(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		t.Parallel()
 
-		cells, err := LatLngToCellsBatch(nil, 9)
+		cells, err := LatLngToCellBatch(nil, 9)
 		assertNil(t, cells)
 		assertNil(t, err)
 	})
@@ -155,7 +155,7 @@ func TestLatLngToCellsBatch(t *testing.T) {
 	t.Run("single element", func(t *testing.T) {
 		t.Parallel()
 
-		cells, err := LatLngToCellsBatch([]LatLng{validLatLng1}, 5)
+		cells, err := LatLngToCellBatch([]LatLng{validLatLng1}, 5)
 		assertNoErr(t, err)
 		assertEqual(t, 1, len(cells))
 		assertEqual(t, validCell, cells[0])
@@ -164,7 +164,7 @@ func TestLatLngToCellsBatch(t *testing.T) {
 	t.Run("invalid resolution surfaces error", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := LatLngToCellsBatch([]LatLng{validLatLng1}, MaxResolution+1)
+		_, err := LatLngToCellBatch([]LatLng{validLatLng1}, MaxResolution+1)
 		assertErr(t, err)
 		assertErrIs(t, err, ErrResolutionDomain)
 	})


### PR DESCRIPTION
## Resolves #113 

Adds `LatLngToCellBatch` so a slice of `LatLng` -> `[]Cell` costs one cgo transaction for the whole batch instead of one per row. The motivating use case is pipelines transforming millions of coordinate rows per cycle, where cgo overhead currently dominates actual H3 work.

Per @jogly's suggestion in the issue, the implementation lives in a new C extension (`h3_latLngBatch.{c,h}`) that supplements the cloned H3 core. If H3 core later exposes and equivalent `latLngToCellBatch`, swapping the Go wrapper to call it directly is a one-line change.

### Changes

| File | Change |
|---|---|
| `h3_latLngBatch.h` (new) | Declaration of `latLngToCellBatch` |
| `h3_latLngBatch.c` (new) | C-side loop calling `latLngToCell`  |
| `h3.go` | `#include <h3_latLngBatch.h>`  in cgo preamble; new `LatLngToCellBatch` wrapper |
| `h3_test.go` | Parity tests against per-call across all resolutions, empty input, single element, invalid resolution |
| `bench_test.go` | `BenchmarkLatLngToCellBatch` plus a `BenchmarkLatLngToCellBaseline` for comparing results |

### Benchmark

```
goos: darwin
goarch: arm64
pkg: github.com/uber/h3-go/v4
cpu: Apple M1
BenchmarkLatLngToCellsBatch/1-8                  7131451           319.4 ns/op
BenchmarkLatLngToCellsBatch/64-8                  144639           16473 ns/op
BenchmarkLatLngToCellsBatch/1024-8                  8794           263703 ns/op
BenchmarkLatLngToCellsBatch/16384-8                  564           4244748 ns/op
BenchmarkLatLngToCellsBatch/1000000-8                  8           259712438 ns/op
BenchmarkLatLngToCellsBatch/10000000-8                 1           2623521042 ns/op
BenchmarkLatLngToCellsBaseline/1-8               7072687           309.8 ns/op
BenchmarkLatLngToCellsBaseline/64-8               120739           19834 ns/op
BenchmarkLatLngToCellsBaseline/1024-8               7389           319792 ns/op
BenchmarkLatLngToCellsBaseline/16384-8               465           5118101 ns/op
BenchmarkLatLngToCellsBaseline/1000000-8               7           312783863 ns/op
BenchmarkLatLngToCellsBaseline/10000000-8              1           3151075250 ns/op
```

At small `n` (`n < 32`) the per-call path wins. The crossover is around `n=16-32`; from there the batched version grows roughly linearly while the loop pays the cgo cost N times. At `n=16384` the batched version is ~1.21x faster

### Conventions

- Returns first error encountered, no partial results.
- Conversion of degrees -> radians happens in Go via the existing `LatLng.toC()`, so the C code sees radians-LatLng identical to the single-call path.
- No changes to public types or existing function signatures.