### PR TITLE
perf: reimplement bit-manipulation functions in pure Go

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -14,13 +14,16 @@ var (
 		Lat: 38,
 		Lng: -121,
 	}
-	latlngStr  string
-	cell, _    = LatLngToCell(geo, 15)
-	addr       = cell.String()
-	geoBndry   CellBoundary
-	cells      []Cell
-	disks      [][]Cell
-	distResult float64
+	latlngStr   string
+	cell, _     = LatLngToCell(geo, 15)
+	addr        = cell.String()
+	geoBndry    CellBoundary
+	cells       []Cell
+	disks       [][]Cell
+	distResult  float64
+	boolResult  bool
+	intResult   int
+	validResult bool
 )
 
 func BenchmarkToString(b *testing.B) {
@@ -102,5 +105,41 @@ func BenchmarkGreatCircleDistanceKm(b *testing.B) {
 func BenchmarkGreatCircleDistanceM(b *testing.B) {
 	for range b.N {
 		distResult = GreatCircleDistanceM(geo, geo2)
+	}
+}
+
+func BenchmarkResolution(b *testing.B) {
+	for range b.N {
+		intResult = cell.Resolution()
+	}
+}
+
+func BenchmarkBaseCellNumber(b *testing.B) {
+	for range b.N {
+		intResult = cell.BaseCellNumber()
+	}
+}
+
+func BenchmarkIsValid(b *testing.B) {
+	for range b.N {
+		boolResult = cell.IsValid()
+	}
+}
+
+func BenchmarkIsPentagon(b *testing.B) {
+	for range b.N {
+		boolResult = cell.IsPentagon()
+	}
+}
+
+func BenchmarkIsResClassIII(b *testing.B) {
+	for range b.N {
+		boolResult = cell.IsResClassIII()
+	}
+}
+
+func BenchmarkIsValidIndex(b *testing.B) {
+	for range b.N {
+		validResult = IsValidIndex(cell)
 	}
 }

--- a/h3.go
+++ b/h3.go
@@ -35,6 +35,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/bits"
 	"strconv"
 	"strings"
 	"unsafe"
@@ -60,6 +61,14 @@ const (
 	// InvalidH3Index is a sentinel value for an invalid H3 index.
 	InvalidH3Index = C.H3_NULL
 
+	// DegsToRads converts degrees to radians by multiplying degrees by this constant.
+	DegsToRads = math.Pi / 180.0
+	// RadsToDegs converts radians to degrees by multiplying radians by this constant.
+	RadsToDegs = 180.0 / math.Pi
+)
+
+// Internal constants
+const (
 	base16  = 16
 	bitSize = 64
 
@@ -67,19 +76,34 @@ const (
 	numEdgeCells    = 2
 	numCellVertexes = 6
 
-	// DegsToRads converts degrees to radians by multiplying degrees by this constant.
-	DegsToRads = math.Pi / 180.0
-	// RadsToDegs converts radians to degrees by multiplying radians by this constant.
-	RadsToDegs = 180.0 / math.Pi
-)
-
-const (
 	latLngFloatPrecision = 5
 	// latLngStringSize is the size to pre-allocate the buffer for.
 	// Given latLngFloatPrecision, a typical string is "(DD.DDDDD, -DDD.DDDDD)"
 	// which is ~25-30 bytes. 32 is a safe and efficient capacity to start with
 	// to avoid re-allocation.
 	latLngStringSize = 32
+
+	cellMode         = C.H3_CELL_MODE
+	directedEdgeMode = C.H3_DIRECTEDEDGE_MODE
+	vertexMode       = C.H3_VERTEX_MODE
+	modeOffset       = C.H3_MODE_OFFSET
+	reservedOffset   = C.H3_RESERVED_OFFSET
+	resolutionOffset = C.H3_RES_OFFSET
+	baseCellOffset   = C.H3_BC_OFFSET
+	perDigitOffset   = C.H3_PER_DIGIT_OFFSET
+	digitMask        = C.H3_DIGIT_MASK
+
+	resolutionMask = 0xF  // 4 bits
+	baseCellMask   = 0x7F // 7 bits
+	modeMask       = 0xF  // 4 bits
+
+	// digitRegionOffset is the number of non-digit bits above the 15×3-bit
+	// digit region (high + mode + reserved + resolution + base cell = 19).
+	digitRegionOffset = bitSize - MaxResolution*perDigitOffset
+
+	// validCellTopBits is the expected value of the top 8 bits of a valid cell:
+	// high bit=0, mode=1 (cell), reserved=000.
+	validCellTopBits = 0b00001000
 )
 
 var (
@@ -104,6 +128,14 @@ var (
 	}
 	// compile-time check: pow7 must have exactly MaxResolution+1 entries.
 	_ = pow7[MaxResolution]
+
+	// isBaseCellPentagonArr maps base cell number to whether it is a pentagon.
+	// There are exactly 12 pentagons at every resolution, one for each vertex
+	// of the icosahedron.
+	isBaseCellPentagonArr = [128]bool{
+		4: true, 14: true, 24: true, 38: true, 49: true, 58: true,
+		63: true, 72: true, 83: true, 97: true, 107: true, 117: true,
+	}
 )
 
 // PolygonToCells containment modes
@@ -795,7 +827,7 @@ func (v Vertex) Resolution() int {
 // BaseCellNumber returns the integer ID (0-121) of the base cell the H3Index h
 // belongs to.
 func BaseCellNumber(h Cell) int {
-	return int(C.getBaseCellNumber(C.H3Index(h)))
+	return baseCellNumber(h)
 }
 
 // BaseCellNumber returns the integer ID (0-121) of the base cell the H3Index h
@@ -864,7 +896,7 @@ func (c *Cell) UnmarshalText(text []byte) error {
 
 // IsValid returns if a Cell is a valid cell (hexagon or pentagon).
 func (c Cell) IsValid() bool {
-	return c != 0 && C.isValidCell(C.H3Index(c)) == 1
+	return c != 0 && isValidCell(c)
 }
 
 // Parent returns the parent or grandparent Cell of this Cell.
@@ -913,12 +945,12 @@ func (c Cell) CenterChild(resolution int) (Cell, error) {
 // IsResClassIII returns true if this is a class III index. If false, this is a
 // class II index.
 func (c Cell) IsResClassIII() bool {
-	return C.isResClassIII(C.H3Index(c)) == 1
+	return c.Resolution()%2 == 1
 }
 
 // IsPentagon returns true if this is a pentagon.
 func (c Cell) IsPentagon() bool {
-	return C.isPentagon(C.H3Index(c)) == 1
+	return isPentagonCell(c)
 }
 
 // IcosahedronFaces finds all icosahedron faces (0-19) intersected by this Cell.
@@ -1248,8 +1280,20 @@ func (v *Vertex) UnmarshalText(text []byte) error {
 
 // IsValidIndex returns whether the given index is valid.
 // This is a generic function that accepts any H3 index type (Cell, DirectedEdge, or Vertex).
+// Cell validation is pure Go bit manipulation. DirectedEdge and Vertex validation
+// call through to CGo because they require coordinate geometry (cell traversal
+// and canonical vertex reconstruction) beyond bit operations.
 func IsValidIndex[T Index](index T) bool {
-	return C.isValidIndex(C.H3Index(index)) == 1
+	switch mode(index) {
+	case cellMode:
+		return index != 0 && isValidCell(Cell(index))
+	case directedEdgeMode:
+		return C.isValidDirectedEdge(C.H3Index(index)) == 1
+	case vertexMode:
+		return C.isValidVertex(C.H3Index(index)) == 1
+	default:
+		return false
+	}
 }
 
 // IndexDigit returns an [indexing digit] of the vertex.
@@ -1432,9 +1476,9 @@ func intsFromC(chs []C.int) []int {
 func (g LatLng) String() string {
 	buf := make([]byte, 0, latLngStringSize)
 	buf = append(buf, '(')
-	buf = strconv.AppendFloat(buf, g.Lat, 'f', latLngFloatPrecision, 64) //nolint:mnd // float bit size
+	buf = strconv.AppendFloat(buf, g.Lat, 'f', latLngFloatPrecision, bitSize)
 	buf = append(buf, ',', ' ')
-	buf = strconv.AppendFloat(buf, g.Lng, 'f', latLngFloatPrecision, 64) //nolint:mnd // float bit size
+	buf = strconv.AppendFloat(buf, g.Lng, 'f', latLngFloatPrecision, bitSize)
 	buf = append(buf, ')')
 	return string(buf)
 }
@@ -1470,7 +1514,95 @@ func indexDigit[I Index](index I, resolution int) (int, error) {
 }
 
 func resolution[I Index](index I) int {
-	return int(C.getResolution(C.H3Index(index)))
+	return int(index>>resolutionOffset) & resolutionMask
+}
+
+func baseCellNumber[I Index](index I) int {
+	return int(index>>baseCellOffset) & baseCellMask
+}
+
+func mode[I Index](index I) int {
+	return int(index>>modeOffset) & modeMask
+}
+
+func isValidCell(c Cell) bool {
+	h := uint64(c)
+	// Top 8 bits: high=0, mode=1 (cell), reserved=0 => 0b00001000.
+	if h>>reservedOffset != validCellTopBits {
+		return false
+	}
+	bc := baseCellNumber(c)
+	if bc >= NumBaseCells {
+		return false
+	}
+	res := resolution(c)
+	if hasAny7UptoRes(h, res) {
+		return false
+	}
+	if !hasAll7AfterRes(h, res) {
+		return false
+	}
+	if hasDeletedSubsequence(h, bc) {
+		return false
+	}
+	return true
+}
+
+// hasAny7UptoRes detects whether any digit from 1 to res is 7 (invalid)
+// without looping, using the carry-based trick from h3_h3Index.c:_hasAny7UptoRes.
+//
+// mhi selects the high bit of each 3-bit digit (100 100 100 ...), and
+// mlo selects the low bit (001 001 001 ...). For a digit that is 7 (0b111),
+// its complement is 0b000, and subtracting mlo borrows into the high bit.
+// The final AND keeps only high bits where this borrow occurred, so any
+// non-zero result means at least one digit is 7.
+func hasAny7UptoRes(h uint64, res int) bool {
+	const mhi uint64 = 0b100100100100100100100100100100100100100100100
+	const mlo = mhi >> 2
+	shift := perDigitOffset * (MaxResolution - res)
+	h >>= shift
+	h <<= shift
+	h = h & mhi & (^h - mlo)
+	return h != 0
+}
+
+func hasAll7AfterRes(h uint64, res int) bool {
+	if res >= MaxResolution {
+		return true
+	}
+	shift := digitRegionOffset + perDigitOffset*res
+	h = ^h
+	h <<= shift
+	h >>= shift
+	return h == 0
+}
+
+func hasDeletedSubsequence(h uint64, baseCell int) bool {
+	if !isBaseCellPentagonArr[baseCell] {
+		return false
+	}
+	h <<= digitRegionOffset
+	h >>= digitRegionOffset
+	if h == 0 {
+		return false
+	}
+	return firstOneIndex(h)%perDigitOffset == 0
+}
+
+func firstOneIndex(h uint64) int {
+	return (bitSize - 1) - bits.LeadingZeros64(h)
+}
+
+func isPentagonCell(c Cell) bool {
+	if !isBaseCellPentagonArr[baseCellNumber(c)] {
+		return false
+	}
+	for r := 1; r <= resolution(c); r++ {
+		if (c>>((MaxResolution-r)*perDigitOffset))&digitMask != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func indexToString[I Index](index I) string {

--- a/h3_test.go
+++ b/h3_test.go
@@ -407,6 +407,28 @@ func TestIsValid(t *testing.T) {
 	t.Parallel()
 	assertTrue(t, validCell.IsValid())
 	assertFalse(t, Cell(0).IsValid())
+
+	// Resolution 15 exercises hasAll7AfterRes with res == MaxResolution.
+	res15Cell, _ := LatLngToCell(validLatLng1, MaxResolution)
+	assertTrue(t, res15Cell.IsValid())
+
+	// Wrong mode (directed edge mode in top bits).
+	assertFalse(t, Cell(0x1000000000000000).IsValid())
+
+	// Base cell number >= NumBaseCells (122).
+	assertFalse(t, Cell(0x080f500000000000|0x1fffffffffff).IsValid())
+
+	// Digit 7 in active position (base cell 1, res 1, digit 1 = 7).
+	assertFalse(t, Cell(0x08103fffffffffff).IsValid())
+
+	// Digits after resolution not all 7 (res 1, digit 1 = 2, rest zeroed).
+	assertFalse(t, Cell(0x0810080000000000).IsValid())
+
+	// Deleted subsequence: pentagon base cell 4, res 1, digit 1 = 1 (K_AXES_DIGIT).
+	assertFalse(t, Cell(0x081087ffffffffff).IsValid())
+
+	// Pentagon base cell 4 at res 15 with all digits 0 is a valid pentagon center.
+	assertTrue(t, Cell(0x08f0800000000000).IsValid())
 }
 
 func TestRoundtrip(t *testing.T) {
@@ -563,6 +585,9 @@ func TestIsPentagon(t *testing.T) {
 	t.Parallel()
 	assertFalse(t, validCell.IsPentagon())
 	assertTrue(t, pentagonCell.IsPentagon())
+
+	// Pentagon base cell 4, res 1, digit 1 = 2: valid cell but not a pentagon.
+	assertFalse(t, Cell(0x08108bffffffffff).IsPentagon())
 }
 
 func TestIsNeighbor(t *testing.T) {


### PR DESCRIPTION
Replace CGo calls with pure Go bit operations for Resolution, BaseCellNumber, IsResClassIII, IsPentagon, IsValid (Cell), and IsValidIndex. This eliminates the ~18ns CGo crossing overhead per call, yielding 10-63x speedups on these hot-path functions.

Before (CGo):

```lang=bash
BenchmarkResolution-16        	67765814	        17.77 ns/op	       0 B/op	       0 allocs/op
BenchmarkBaseCellNumber-16    	69139195	        17.34 ns/op	       0 B/op	       0 allocs/op
BenchmarkIsValid-16           	63857523	        19.07 ns/op	       0 B/op	       0 allocs/op
BenchmarkIsPentagon-16        	64660398	        18.76 ns/op	       0 B/op	       0 allocs/op
BenchmarkIsResClassIII-16     	66036112	        18.23 ns/op	       0 B/op	       0 allocs/op
BenchmarkIsValidIndex-16      	63598622	        19.11 ns/op	       0 B/op	       0 allocs/op
```

After (pure Go):

```lang=bash
BenchmarkResolution-16        	1000000000	         0.2806 ns/op	       0 B/op	       0 allocs/op
BenchmarkBaseCellNumber-16    	1000000000	         0.2868 ns/op	       0 B/op	       0 allocs/op
BenchmarkIsValid-16           	600393506	         2.014 ns/op	       0 B/op	       0 allocs/op
BenchmarkIsPentagon-16        	1000000000	         0.6200 ns/op	       0 B/op	       0 allocs/op
BenchmarkIsResClassIII-16     	1000000000	         0.3155 ns/op	       0 B/op	       0 allocs/op
BenchmarkIsValidIndex-16      	492134308	         2.430 ns/op	       0 B/op	       0 allocs/op
```

benchstat (n=10):

```lang=bash
                  │   old (CGo)   │            new (pure Go)             │
                  │    sec/op     │    sec/op     vs base                │
Resolution-16       17.5300n ± 2%   0.2801n ± 1%  -98.40% (p=0.000 n=10)
BaseCellNumber-16   17.4500n ± 1%   0.2874n ± 2%  -98.35% (p=0.000 n=10)
IsValid-16           19.070n ± 1%    1.998n ± 3%  -89.52% (p=0.000 n=10)
IsPentagon-16       18.7600n ± 1%   0.6010n ± 8%  -96.80% (p=0.000 n=10)
IsResClassIII-16    17.9800n ± 2%   0.3127n ± 3%  -98.26% (p=0.000 n=10)
IsValidIndex-16      18.840n ± 0%    2.573n ± 8%  -86.35% (p=0.000 n=10)
geomean               18.26n        0.6533n       -96.42%
```