### PR TITLE
perf: reimplement greatCircle* as pure Go

### DIFF
--- a/h3.go
+++ b/h3.go
@@ -92,6 +92,7 @@ const (
 	baseCellOffset   = C.H3_BC_OFFSET
 	perDigitOffset   = C.H3_PER_DIGIT_OFFSET
 	digitMask        = C.H3_DIGIT_MASK
+	earthRadiusKm    = C.EARTH_RADIUS_KM
 
 	resolutionMask = 0xF  // 4 bits
 	baseCellMask   = 0x7F // 7 bits
@@ -671,22 +672,28 @@ func CellsToMultiPolygon(cells []Cell) ([]GeoPolygon, error) {
 // GreatCircleDistanceRads returns the "great circle" or "haversine" distance between
 // pairs of LatLng points (lat/lng pairs) in radians.
 func GreatCircleDistanceRads(a, b LatLng) float64 {
-	ca, cb := a.toC(), b.toC()
-	return float64(C.greatCircleDistanceRads(&ca, &cb))
+	aLat := DegsToRads * a.Lat
+	aLng := DegsToRads * a.Lng
+	bLat := DegsToRads * b.Lat
+	bLng := DegsToRads * b.Lng
+
+	sinLat := math.Sin((bLat - aLat) * 0.5) //nolint:mnd // haversine formula
+	sinLng := math.Sin((bLng - aLng) * 0.5) //nolint:mnd // haversine formula
+
+	h := sinLat*sinLat + math.Cos(aLat)*math.Cos(bLat)*sinLng*sinLng
+	return 2 * math.Atan2(math.Sqrt(h), math.Sqrt(1-h)) //nolint:mnd // haversine formula
 }
 
 // GreatCircleDistanceKm returns the "great circle" or "haversine" distance between pairs
 // of LatLng points (lat/lng pairs) in kilometers.
 func GreatCircleDistanceKm(a, b LatLng) float64 {
-	ca, cb := a.toC(), b.toC()
-	return float64(C.greatCircleDistanceKm(&ca, &cb))
+	return GreatCircleDistanceRads(a, b) * earthRadiusKm
 }
 
 // GreatCircleDistanceM returns the "great circle" or "haversine" distance between pairs
 // of LatLng points (lat/lng pairs) in meters.
 func GreatCircleDistanceM(a, b LatLng) float64 {
-	ca, cb := a.toC(), b.toC()
-	return float64(C.greatCircleDistanceM(&ca, &cb))
+	return GreatCircleDistanceKm(a, b) * 1000 //nolint:mnd // unit conversion
 }
 
 // HexagonAreaAvgKm2 returns the average hexagon area in square kilometers at the given


### PR DESCRIPTION
Eliminate CGo overhead by implementing the haversine formula directly in Go. Benchstat shows ~66% faster execution and zero allocations.

Before (CGo):

```lang=bash
BenchmarkGreatCircleDistanceRads-16    	19489219	        62.82 ns/op	      32 B/op	       2 allocs/op
BenchmarkGreatCircleDistanceKm-16      	19358064	        62.81 ns/op	      32 B/op	       2 allocs/op
BenchmarkGreatCircleDistanceM-16       	18969169	        63.68 ns/op	      32 B/op	       2 allocs/op
```

After (pure Go):

```lang=bash
BenchmarkGreatCircleDistanceRads-16    	58551271	        20.70 ns/op	       0 B/op	       0 allocs/op
BenchmarkGreatCircleDistanceKm-16      	57732436	        21.12 ns/op	       0 B/op	       0 allocs/op
BenchmarkGreatCircleDistanceM-16       	56447564	        21.64 ns/op	       0 B/op	       0 allocs/op
```

Benchstat:

```lang=bash
                           │   old (CGo)   │         new (pure Go)          │
                           │    sec/op     │   sec/op     vs base           │
GreatCircleDistanceRads-16   62.82n ± 2%   20.70n ± 1%  -67.06% (p=0.000 n=10)
GreatCircleDistanceKm-16     62.81n ± 1%   21.12n ± 2%  -66.37% (p=0.000 n=10)
GreatCircleDistanceM-16      63.68n ± 0%   21.64n ± 2%  -66.01% (p=0.000 n=10)
geomean                      63.10n        21.15n       -66.48%

                           │  old (CGo)  │       new (pure Go)        │
                           │    B/op     │   B/op     vs base         │
GreatCircleDistanceRads-16   32.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=10)
GreatCircleDistanceKm-16     32.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=10)
GreatCircleDistanceM-16      32.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=10)

                           │  old (CGo)  │       new (pure Go)        │
                           │  allocs/op  │ allocs/op   vs base        │
GreatCircleDistanceRads-16   2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
GreatCircleDistanceKm-16     2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
GreatCircleDistanceM-16      2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
```