### PR TITLE
feat: add LatLngToCellString helper

### DIFF
--- a/h3.go
+++ b/h3.go
@@ -272,6 +272,17 @@ func (g LatLng) Cell(resolution int) (Cell, error) {
 	return LatLngToCell(g, resolution)
 }
 
+// LatLngToCellString returns the string representation of the Cell at
+// resolution for a geographic coordinate. It is a convenience wrapper for
+// LatLngToCell followed by Cell.String.
+func LatLngToCellString(latitude, longitude float64, resolution int) (string, error) {
+	cell, err := NewLatLng(latitude, longitude).Cell(resolution)
+	if err != nil {
+		return "", err
+	}
+	return cell.String(), nil
+}
+
 // CellToLatLng returns the geographic centerpoint of a Cell.
 func CellToLatLng(c Cell) (LatLng, error) {
 	var g C.LatLng

--- a/h3_test.go
+++ b/h3_test.go
@@ -121,6 +121,18 @@ func TestLatLngToCell(t *testing.T) {
 	assertErrIs(t, err, ErrResolutionDomain)
 }
 
+func TestLatLngToCellString(t *testing.T) {
+	t.Parallel()
+
+	cellStr, err := LatLngToCellString(validLatLng1.Lat, validLatLng1.Lng, 5)
+	assertEqual(t, validCell.String(), cellStr)
+	assertNoErr(t, err)
+
+	_, err = LatLngToCellString(0, 0, MaxResolution+1)
+	assertErr(t, err)
+	assertErrIs(t, err, ErrResolutionDomain)
+}
+
 func TestCellToLatLng(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Convenience wrapper for LatLngToCell followed by Cell.String, for the common case of indexing a coordinate and getting its string form.