### PR TITLE
feat: add pure-Go CellToLatLng & CellToBoundary to x/h3go

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,6 +69,11 @@ linters:
           - goconst
           - gosec
           - govet
+      # x/h3go is a pure-Go reimplementation of H3's geometry: the geometric and
+      # bit-layout constants are inherent to the algorithms, not tunable magic.
+      - path: x/h3go/
+        linters:
+          - mnd
 
 formatters:
   enable:

--- a/x/h3go/boundary.go
+++ b/x/h3go/boundary.go
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2026 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package h3go
+
+// CellToBoundary returns the geographic boundary of a cell as an ordered list of
+// vertices in degrees.
+func CellToBoundary(c Cell) (CellBoundary, error) {
+	return c.Boundary()
+}
+
+// Boundary returns the geographic boundary of the cell as an ordered list of
+// vertices in degrees.
+func (c Cell) Boundary() (CellBoundary, error) {
+	fijk, err := c.toFaceIjk()
+	if err != nil {
+		return nil, err
+	}
+
+	res := c.Resolution()
+	if c.IsPentagon() {
+		return fijk.pentToCellBoundary(res, 0, numPentVerts), nil
+	}
+
+	return fijk.toCellBoundary(res, 0, numHexVerts), nil
+}
+
+// toCellBoundary builds the geographic boundary of a hexagon cell from its
+// FaceIJK address. It walks length topological vertices starting at start,
+// adjusting each onto the correct face and inserting an extra vertex wherever a
+// Class III cell edge crosses an icosahedron face edge (so each half of the edge
+// projects with the correct face). start and length select a sub-range of the
+// loop, which directed-edge boundaries use to project a single edge.
+func (fijk faceIJK) toCellBoundary(res, start, length int) CellBoundary {
+	adjRes, fijkVerts := fijk.toVerts(res)
+	centerFace := fijk.face
+
+	// When returning the whole loop, run one extra iteration to catch a
+	// distortion vertex on the last edge.
+	additionalIteration := 0
+	if length == numHexVerts {
+		additionalIteration = 1
+	}
+
+	var boundary CellBoundary
+
+	lastFace := -1
+	lastOverage := noOverage
+
+	for vert := start; vert < start+length+additionalIteration; vert++ {
+		v := vert % numHexVerts
+		vfijk := fijkVerts[v]
+
+		var ov overage
+
+		vfijk, ov = vfijk.adjustOverageClassII(adjRes, false, true)
+
+		// Class III cell edges can cross an icosahedron edge; Class II edges have
+		// their vertices on the face edge with no line intersection.
+		if isResClassIII(res) && vert > start && vfijk.face != lastFace && lastOverage != faceEdge {
+			lastV := (v + numHexVerts - 1) % numHexVerts
+			orig2d0 := fijkVerts[lastV].coord.toHex2d()
+			orig2d1 := fijkVerts[v].coord.toHex2d()
+
+			face2 := lastFace
+			if lastFace == centerFace {
+				face2 = vfijk.face
+			}
+
+			edge0, edge1 := icosaEdge(adjRes, adjacentFaceDir[centerFace][face2])
+			inter := orig2d0.intersect(orig2d1, edge0, edge1)
+
+			// If the intersection lands on a hexagon vertex, both adjacent edges
+			// lie on a single face and no extra vertex is needed.
+			if !orig2d0.almostEquals(inter) && !orig2d1.almostEquals(inter) {
+				boundary = append(boundary, inter.toVec3(centerFace, adjRes, true).toLatLng())
+			}
+		}
+
+		// The final extra iteration only tests for an edge intersection.
+		if vert < start+numHexVerts {
+			boundary = append(boundary, vfijk.coord.toHex2d().toVec3(vfijk.face, adjRes, true).toLatLng())
+		}
+
+		lastFace = vfijk.face
+		lastOverage = ov
+	}
+
+	return boundary
+}
+
+// pentToCellBoundary builds the geographic boundary of a pentagon cell from its
+// FaceIJK address. Every Class III pentagon edge crosses an icosahedron edge, so
+// a crossing vertex is inserted on each such edge. start and length select a
+// sub-range of the loop, which directed-edge boundaries use to project a single
+// edge.
+func (fijk faceIJK) pentToCellBoundary(res, start, length int) CellBoundary {
+	adjRes, fijkVerts := fijk.pentToVerts(res)
+
+	additionalIteration := 0
+	if length == numPentVerts {
+		additionalIteration = 1
+	}
+
+	var boundary CellBoundary
+
+	var lastFijk faceIJK
+
+	for vert := start; vert < start+length+additionalIteration; vert++ {
+		v := vert % numPentVerts
+		vfijk := fijkVerts[v]
+		vfijk, _ = vfijk.adjustPentVertOverage(adjRes)
+
+		if isResClassIII(res) && vert > start {
+			orig2d0 := lastFijk.coord.toHex2d()
+
+			// Re-express the current vertex on the previous vertex's face so the
+			// two 2D points share a coordinate system for the intersection.
+			currentToLastDir := adjacentFaceDir[vfijk.face][lastFijk.face]
+			fijkOrient := faceNeighbors[vfijk.face][currentToLastDir]
+
+			tmpFijk := faceIJK{face: fijkOrient.face, coord: vfijk.coord}
+
+			ijk := tmpFijk.coord
+			for range fijkOrient.ccwRot60 {
+				ijk = ijk.rotate60ccw()
+			}
+
+			ijk = ijk.add(fijkOrient.translate.scale(unitScaleByCIIres[adjRes] * 3))
+			ijk.normalize()
+			tmpFijk.coord = ijk
+
+			orig2d1 := ijk.toHex2d()
+
+			edge0, edge1 := icosaEdge(adjRes, adjacentFaceDir[tmpFijk.face][vfijk.face])
+			inter := orig2d0.intersect(orig2d1, edge0, edge1)
+			boundary = append(boundary, inter.toVec3(tmpFijk.face, adjRes, true).toLatLng())
+		}
+
+		if vert < start+numPentVerts {
+			boundary = append(boundary, vfijk.coord.toHex2d().toVec3(vfijk.face, adjRes, true).toLatLng())
+		}
+
+		lastFijk = vfijk
+	}
+
+	return boundary
+}
+
+// icosaEdge returns the two 2D substrate endpoints of the icosahedron face edge
+// in the given direction (dirIJ/dirJK/dirKI) at the given Class II resolution.
+// These bound the segment a crossing cell edge is intersected against.
+func icosaEdge(res, dir int) (edge0, edge1 vec2d) {
+	maxDim := float64(maxDimByCIIres[res])
+	v0 := vec2d{x: 3.0 * maxDim, y: 0.0}
+	v1 := vec2d{x: -1.5 * maxDim, y: 3.0 * mSqrt3Half * maxDim}
+	v2 := vec2d{x: -1.5 * maxDim, y: -3.0 * mSqrt3Half * maxDim}
+
+	switch dir {
+	case dirIJ:
+		return v0, v1
+	case dirJK:
+		return v1, v2
+	default: // dirKI
+		return v2, v0
+	}
+}

--- a/x/h3go/boundary_test.go
+++ b/x/h3go/boundary_test.go
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2026 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package h3go
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// maxCellBoundaryVerts bounds how many vertices a cell boundary can have: each
+// topological vertex plus at most one distortion vertex per edge.
+const maxCellBoundaryVerts = 2 * numHexVerts
+
+// reverseCorpus builds a rich set of cells for the reverse-projection white-box
+// tests. It combines the shared corpus, the descendants of every pentagon (which
+// reach the pentagon rotation and overage branches), and a large deterministic
+// random sweep that drives cells through every Class III edge-crossing path.
+func reverseCorpus(t *testing.T) []Cell {
+	t.Helper()
+
+	cells := corpus(t)
+
+	pents, err := Pentagons(0)
+	if err != nil {
+		t.Fatalf("Pentagons(0): %v", err)
+	}
+
+	for _, pent := range pents {
+		for res := 1; res <= 3; res++ {
+			children, err := pent.Children(res)
+			if err != nil {
+				t.Fatalf("Children(%015x, %d): %v", uint64(pent), res, err)
+			}
+
+			cells = append(cells, children...)
+		}
+	}
+
+	const (
+		seed       = 2
+		iterations = 60000
+		latSpan    = 180.0
+		latOffset  = 90.0
+		lngSpan    = 360.0
+		lngOffset  = 180.0
+		resCount   = maxResolution + 1
+	)
+
+	rng := rand.New(rand.NewSource(seed))
+	for range iterations {
+		lat := rng.Float64()*latSpan - latOffset
+		lng := rng.Float64()*lngSpan - lngOffset
+
+		c, err := LatLngToCell(LatLng{Lat: lat, Lng: lng}, rng.Intn(resCount))
+		if err != nil {
+			t.Fatalf("LatLngToCell(%v, %v): %v", lat, lng, err)
+		}
+
+		cells = append(cells, c)
+	}
+
+	return cells
+}
+
+// TestCellToBoundarySweep exercises the boundary builders over the reverse
+// corpus and checks each boundary is well-formed: a sane vertex count and every
+// vertex in geographic range. Exact-value correctness is covered by the cgo
+// parity tests.
+func TestCellToBoundarySweep(t *testing.T) {
+	t.Parallel()
+
+	for _, c := range reverseCorpus(t) {
+		boundary, err := CellToBoundary(c)
+		if err != nil {
+			t.Fatalf("CellToBoundary(%015x): %v", uint64(c), err)
+		}
+
+		minVerts := numHexVerts
+		if c.IsPentagon() {
+			minVerts = numPentVerts
+		}
+
+		if len(boundary) < minVerts || len(boundary) > maxCellBoundaryVerts {
+			t.Fatalf("CellToBoundary(%015x): %d vertices, want %d..%d",
+				uint64(c), len(boundary), minVerts, maxCellBoundaryVerts)
+		}
+
+		for i, vert := range boundary {
+			if math.IsNaN(vert.Lat) || math.IsNaN(vert.Lng) ||
+				vert.Lat < -90 || vert.Lat > 90 || vert.Lng < -180 || vert.Lng > 180 {
+				t.Fatalf("CellToBoundary(%015x) vertex %d = %+v: out of range", uint64(c), i, vert)
+			}
+		}
+	}
+}
+
+// TestCellToBoundaryInvalidBaseCell covers the invalid-base-cell error branch of
+// CellToBoundary, which is unreachable from a validly constructed cell.
+func TestCellToBoundaryInvalidBaseCell(t *testing.T) {
+	t.Parallel()
+
+	bad := Cell(h3Init) | Cell(cellMode)<<modeOffset | Cell(numBaseCells)<<baseCellOffset
+
+	if _, err := CellToBoundary(bad); err == nil {
+		t.Fatalf("CellToBoundary(%015x): got nil error, want ErrCellInvalid", uint64(bad))
+	}
+}
+
+// TestCellToBoundaryClassIIIEdgeVertex is the regression for uber/h3#45: each of
+// these Class III cells has a distortion vertex on a Class III edge and so must
+// report seven boundary vertices.
+func TestCellToBoundaryClassIIIEdgeVertex(t *testing.T) {
+	t.Parallel()
+
+	hexes := []string{
+		"894cc5349b7ffff", "894cc534d97ffff", "894cc53682bffff",
+		"894cc536b17ffff", "894cc53688bffff", "894cead92cbffff",
+		"894cc536537ffff", "894cc5acbabffff", "894cc536597ffff",
+	}
+
+	for _, hex := range hexes {
+		t.Run(hex, func(t *testing.T) {
+			t.Parallel()
+
+			boundary, err := CellToBoundary(CellFromString(hex))
+			if err != nil {
+				t.Fatalf("CellToBoundary(%s): %v", hex, err)
+			}
+
+			if len(boundary) != 7 {
+				t.Fatalf("CellToBoundary(%s): %d vertices, want 7", hex, len(boundary))
+			}
+		})
+	}
+}
+
+// TestCellToBoundaryKnownValues pins boundaries to exact values for cells from
+// the reported bugs uber/h3#45 (a Class III distortion vertex) and uber/h3#212
+// (a cos-longitude constraint near a face edge).
+func TestCellToBoundaryKnownValues(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		giveCell string
+		wantLoop CellBoundary
+	}{
+		"class_iii_edge_vertex_exact": {
+			giveCell: "894cc536537ffff",
+			wantLoop: CellBoundary{
+				{18.043333154, -66.27836523500002},
+				{18.042238363, -66.27929062800001},
+				{18.040818259, -66.27854193899998},
+				{18.040492975, -66.27686786700002},
+				{18.041040385, -66.27640518300001},
+				{18.041757122, -66.27596711500001},
+				{18.043007860, -66.27669118199998},
+			},
+		},
+		"coslng_constrain": {
+			giveCell: "87dc6d364ffffff",
+			wantLoop: CellBoundary{
+				{-52.0130533678236091, -34.6232931343713091},
+				{-52.0041156384652012, -34.6096733160584549},
+				{-51.9929610229502472, -34.6165157145896387},
+				{-51.9907410568096608, -34.6369680004259877},
+				{-51.9996738734672377, -34.6505896528323660},
+				{-52.0108315681413629, -34.6437571897165668},
+			},
+		},
+	}
+
+	const tolDegs = 1e-7
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := CellToBoundary(CellFromString(tt.giveCell))
+			if err != nil {
+				t.Fatalf("CellToBoundary(%s): %v", tt.giveCell, err)
+			}
+
+			if len(got) != len(tt.wantLoop) {
+				t.Fatalf("CellToBoundary(%s): %d vertices, want %d", tt.giveCell, len(got), len(tt.wantLoop))
+			}
+
+			for i := range tt.wantLoop {
+				if math.Abs(got[i].Lat-tt.wantLoop[i].Lat) > tolDegs ||
+					math.Abs(got[i].Lng-tt.wantLoop[i].Lng) > tolDegs {
+					t.Fatalf("CellToBoundary(%s) vertex %d = %+v, want %+v", tt.giveCell, i, got[i], tt.wantLoop[i])
+				}
+			}
+		})
+	}
+}
+
+// TestCellToBoundaryDoublePrecisionVertex is the regression for the double-
+// precision edge-intersection case in the cgo reference: a res-1 pentagon whose
+// distortion vertices shift between float and double precision. The boundary
+// must be geometrically consistent with indexing — a point that indexes to the
+// cell must fall inside the boundary, and a point that does not must fall
+// outside.
+func TestCellToBoundaryDoublePrecisionVertex(t *testing.T) {
+	t.Parallel()
+
+	const cellHex = "81083ffffffffff"
+
+	point := LatLng{Lat: 61.890838431, Lng: 8.644221328}
+	cell := CellFromString(cellHex)
+
+	boundary, err := CellToBoundary(cell)
+	if err != nil {
+		t.Fatalf("CellToBoundary(%s): %v", cellHex, err)
+	}
+
+	indexed, err := LatLngToCell(point, 1)
+	if err != nil {
+		t.Fatalf("LatLngToCell(%+v, 1): %v", point, err)
+	}
+
+	inside := pointInLoop(boundary, point)
+	if indexed == cell && !inside {
+		t.Fatalf("point %+v indexes to %s but lies outside its boundary", point, cellHex)
+	}
+
+	if indexed != cell && inside {
+		t.Fatalf("point %+v indexes to %015x but lies inside %s's boundary", point, uint64(indexed), cellHex)
+	}
+}
+
+// pointInLoop reports whether a geographic point lies inside the polygon
+// described by loop, using even-odd ray casting in lat/lng. It is sufficient for
+// loops that do not cross the antimeridian.
+func pointInLoop(loop CellBoundary, point LatLng) bool {
+	inside := false
+
+	for i, j := 0, len(loop)-1; i < len(loop); j, i = i, i+1 {
+		yi, xi := loop[i].Lat, loop[i].Lng
+		yj, xj := loop[j].Lat, loop[j].Lng
+
+		if (yi > point.Lat) != (yj > point.Lat) &&
+			point.Lng < (xj-xi)*(point.Lat-yi)/(yj-yi)+xi {
+			inside = !inside
+		}
+	}
+
+	return inside
+}

--- a/x/h3go/convert.go
+++ b/x/h3go/convert.go
@@ -48,13 +48,13 @@ func CellFromString(s string) Cell {
 
 // CellToString returns the hexadecimal string representation of a Cell.
 func CellToString(c Cell) string {
-	//nolint:gosec // an H3 index is a 64-bit value; int64->uint64 is a lossless reinterpretation.
-	return IndexToString(uint64(c))
+	return c.String()
 }
 
 // String returns the hexadecimal string representation of the cell.
 func (c Cell) String() string {
-	return CellToString(c)
+	//nolint:gosec // an H3 index is a 64-bit value; int64->uint64 is a lossless reinterpretation.
+	return IndexToString(uint64(c))
 }
 
 // MarshalText implements the encoding.TextMarshaler interface.

--- a/x/h3go/convert_test.go
+++ b/x/h3go/convert_test.go
@@ -68,6 +68,17 @@ func TestIndexFromString(t *testing.T) {
 	}
 }
 
+// TestCellToString covers the CellToString free function; the implementation
+// lives on the method form (Cell.String), which this delegates to.
+func TestCellToString(t *testing.T) {
+	t.Parallel()
+
+	const hex = "8928308280fffff"
+	if got := CellToString(CellFromString(hex)); got != hex {
+		t.Fatalf("CellToString = %q, want %q", got, hex)
+	}
+}
+
 // TestCellTextMarshaling exercises MarshalText / UnmarshalText, including the
 // invalid-input error path.
 func TestCellTextMarshaling(t *testing.T) {

--- a/x/h3go/faceijk.go
+++ b/x/h3go/faceijk.go
@@ -24,14 +24,14 @@ import (
 
 // --- Face projection ---
 
-// vec3ToClosestFace returns the icosahedron face whose center is nearest to the
-// unit vector v, along with the squared chord distance to that face center. The
+// closestFace returns the icosahedron face whose center is nearest to the unit
+// vector v, along with the squared chord distance to that face center. The
 // nearest face is the one onto which v is gnomonically projected.
-func vec3ToClosestFace(v vec3d) (face int, sqd float64) {
+func (v vec3d) closestFace() (face int, sqd float64) {
 	sqd = 5.0
 
 	for f := range numIcosaFaces {
-		s := vec3DistSq(faceCenterPoint[f], v)
+		s := faceCenterPoint[f].distSq(v)
 		if s < sqd {
 			face = f
 			sqd = s
@@ -41,28 +41,28 @@ func vec3ToClosestFace(v vec3d) (face int, sqd float64) {
 	return face, sqd
 }
 
-// vec3TangentBasis returns an orthonormal basis for the plane tangent to the
-// unit sphere at point p: north points along the projection of the +Z pole onto
-// that plane, and east is perpendicular to it (north × p). Together they let
-// azimuths be measured in the local tangent plane at p.
-func vec3TangentBasis(p vec3d) (north, east vec3d) {
+// tangentBasis returns an orthonormal basis for the plane tangent to the unit
+// sphere at point v: north points along the projection of the +Z pole onto that
+// plane, and east is perpendicular to it (north × v). Together they let azimuths
+// be measured in the local tangent plane at v.
+func (v vec3d) tangentBasis() (north, east vec3d) {
 	northPole := vec3d{0, 0, 1}
-	north = vec3LinComb(1.0, northPole, -vec3Dot(northPole, p), p)
-	vec3Normalize(&north)
-	east = vec3Cross(north, p)
+	north = northPole.linComb(1.0, -northPole.dot(v), v)
+	north.normalize()
+	east = north.cross(v)
 
 	return north, east
 }
 
-// vec3AzimuthRads returns the azimuth, in radians, of point p2 as seen from
-// point p1, measured in p1's local tangent plane (clockwise from north). It is
-// used to find the angle of a geographic point relative to a face center.
-func vec3AzimuthRads(p1, p2 vec3d) float64 {
-	north, east := vec3TangentBasis(p1)
-	p2Proj := vec3LinComb(1.0, p2, -vec3Dot(p2, p1), p1)
-	vec3Normalize(&p2Proj)
+// azimuthRads returns the azimuth, in radians, of point p2 as seen from point v,
+// measured in v's local tangent plane (clockwise from north). It is used to find
+// the angle of a geographic point relative to a face center.
+func (v vec3d) azimuthRads(p2 vec3d) float64 {
+	north, east := v.tangentBasis()
+	p2Proj := p2.linComb(1.0, -p2.dot(v), v)
+	p2Proj.normalize()
 
-	return math.Atan2(vec3Dot(p2Proj, east), vec3Dot(p2Proj, north))
+	return math.Atan2(p2Proj.dot(east), p2Proj.dot(north))
 }
 
 // posAngleRads normalizes an angle in radians into the range [0, 2π).
@@ -79,26 +79,26 @@ func posAngleRads(rads float64) float64 {
 	return tmp
 }
 
-// vec3ToHex2d gnomonically projects the unit vector p onto its closest
-// icosahedron face and returns that face plus the point's 2D Hex coordinates
-// (centered on the face center) at the given resolution. The radius is scaled
-// by √7 per resolution and the angle is rotated for odd (Class III)
-// resolutions. A point at the face center maps to the origin.
-func vec3ToHex2d(p vec3d, res int) (face int, v vec2d) {
+// toHex2d gnomonically projects the unit vector v onto its closest icosahedron
+// face and returns that face plus the point's 2D Hex coordinates (centered on
+// the face center) at the given resolution. The radius is scaled by √7 per
+// resolution and the angle is rotated for odd (Class III) resolutions. A point
+// at the face center maps to the origin.
+func (v vec3d) toHex2d(res int) (face int, hex vec2d) {
 	var sqd float64
 
-	face, sqd = vec3ToClosestFace(p)
+	face, sqd = v.closestFace()
 
 	r := math.Acos(1 - sqd*0.5)
 	if r < epsilon {
-		return face, v
+		return face, hex
 	}
 
 	theta := posAngleRads(
 		faceAxesAzRadsCII[face][0] -
-			posAngleRads(vec3AzimuthRads(faceCenterPoint[face], p)))
+			posAngleRads(faceCenterPoint[face].azimuthRads(v)))
 
-	if res%2 == 1 {
+	if isResClassIII(res) {
 		theta = posAngleRads(theta - mAP7RotRads)
 	}
 
@@ -109,26 +109,26 @@ func vec3ToHex2d(p vec3d, res int) (face int, v vec2d) {
 		r *= mSqrt7
 	}
 
-	v.x = r * math.Cos(theta)
-	v.y = r * math.Sin(theta)
+	hex.x = r * math.Cos(theta)
+	hex.y = r * math.Sin(theta)
 
-	return face, v
+	return face, hex
 }
 
-// vec3ToFaceIjk projects the unit vector p to a face and converts the resulting
-// 2D Hex coordinates into face-centered IJK coordinates at the given resolution.
-func vec3ToFaceIjk(p vec3d, res int) faceIJK {
-	face, v := vec3ToHex2d(p, res)
+// toFaceIjk projects the unit vector v to a face and converts the resulting 2D
+// Hex coordinates into face-centered IJK coordinates at the given resolution.
+func (v vec3d) toFaceIjk(res int) faceIJK {
+	face, hex := v.toHex2d(res)
 
-	return faceIJK{face: face, coord: hex2dToCoordIJK(v)}
+	return faceIJK{face: face, coord: hex.toCoordIJK()}
 }
 
 // --- CoordIJK helpers ---
 
-// ijkNormalize reduces an IJK coordinate to its canonical form by subtracting
-// the minimum component from all three, so that at least one component is zero
-// (IJK coordinates are only defined up to a uniform offset).
-func ijkNormalize(c *coordIJK) {
+// normalize reduces an IJK coordinate to its canonical form by subtracting the
+// minimum component from all three, so that at least one component is zero (IJK
+// coordinates are only defined up to a uniform offset).
+func (c *coordIJK) normalize() {
 	m := c.i
 	if c.j < m {
 		m = c.j
@@ -143,11 +143,141 @@ func ijkNormalize(c *coordIJK) {
 	c.k -= m
 }
 
-// hex2dToCoordIJK converts a 2D Hex coordinate (Cartesian, on a face) into the
+// upAp7 transforms an IJK coordinate to the next coarser resolution on the
+// Class II aperture-7 grid (the "up" direction), rounding to the nearest parent
+// cell and re-normalizing.
+func (c *coordIJK) upAp7() {
+	i := c.i - c.k
+	j := c.j - c.k
+	c.i = int(math.Round(float64(3*i-j) * mOneSeventh))
+	c.j = int(math.Round(float64(i+2*j) * mOneSeventh))
+	c.k = 0
+	c.normalize()
+}
+
+// upAp7r transforms an IJK coordinate to the next coarser resolution on the
+// Class III (rotated) aperture-7 grid, rounding to the nearest parent cell and
+// re-normalizing.
+func (c *coordIJK) upAp7r() {
+	i := c.i - c.k
+	j := c.j - c.k
+	c.i = int(math.Round(float64(2*i+j) * mOneSeventh))
+	c.j = int(math.Round(float64(3*j-i) * mOneSeventh))
+	c.k = 0
+	c.normalize()
+}
+
+// downAp7 transforms an IJK coordinate to the next finer resolution on the
+// Class II aperture-7 grid (the "down" direction, the exact inverse of upAp7),
+// then re-normalizes.
+func (c *coordIJK) downAp7() {
+	i, j, k := c.i, c.j, c.k
+	c.i = 3*i + j
+	c.j = 3*j + k
+	c.k = i + 3*k
+	c.normalize()
+}
+
+// downAp7r transforms an IJK coordinate to the next finer resolution on the
+// Class III (rotated) aperture-7 grid (the inverse of upAp7r), then
+// re-normalizes.
+func (c *coordIJK) downAp7r() {
+	i, j, k := c.i, c.j, c.k
+	c.i = 3*i + k
+	c.j = i + 3*j
+	c.k = j + 3*k
+	c.normalize()
+}
+
+// toDigit maps a unit IJK coordinate (one of the seven cells in a single
+// aperture-7 neighborhood: the center plus its six neighbors) to the
+// corresponding H3 digit (0–6) via a lookup table.
+func (c coordIJK) toDigit() int {
+	c.normalize()
+	i, j, k := c.i, c.j, c.k
+
+	return unitIjkToDigitLUT[i][j][k]
+}
+
+// add returns the component-wise sum of two IJK coordinates.
+func (c coordIJK) add(b coordIJK) coordIJK {
+	return coordIJK{i: c.i + b.i, j: c.j + b.j, k: c.k + b.k}
+}
+
+// scale returns an IJK coordinate with each component multiplied by factor.
+func (c coordIJK) scale(factor int) coordIJK {
+	return coordIJK{i: c.i * factor, j: c.j * factor, k: c.k * factor}
+}
+
+// rotate60ccw returns the IJK coordinate rotated 60° counterclockwise about the
+// origin, re-normalized.
+func (c coordIJK) rotate60ccw() coordIJK {
+	out := coordIJK{i: c.i + c.k, j: c.i + c.j, k: c.j + c.k}
+	out.normalize()
+
+	return out
+}
+
+// rotate60cw returns the IJK coordinate rotated 60° clockwise about the origin,
+// re-normalized.
+func (c coordIJK) rotate60cw() coordIJK {
+	out := coordIJK{i: c.i + c.j, j: c.j + c.k, k: c.i + c.k}
+	out.normalize()
+
+	return out
+}
+
+// downAp3 transforms an IJK coordinate to the next finer resolution on the
+// Class II aperture-3 substrate grid (counterclockwise), then re-normalizes.
+func (c *coordIJK) downAp3() {
+	i, j, k := c.i, c.j, c.k
+	c.i = 2*i + j
+	c.j = 2*j + k
+	c.k = i + 2*k
+	c.normalize()
+}
+
+// downAp3r transforms an IJK coordinate to the next finer resolution on the
+// Class III aperture-3 substrate grid (clockwise), then re-normalizes.
+func (c *coordIJK) downAp3r() {
+	i, j, k := c.i, c.j, c.k
+	c.i = 2*i + k
+	c.j = i + 2*j
+	c.k = j + 2*k
+	c.normalize()
+}
+
+// neighbor returns the IJK coordinate of the cell one step from c in the given
+// digit direction. The center and invalid digits leave the coordinate
+// unchanged.
+func (c coordIJK) neighbor(digit int) coordIJK {
+	if digit > centerDigit && digit < invalidDigit {
+		c = c.add(unitVecs[digit])
+		c.normalize()
+	}
+
+	return c
+}
+
+// toHex2d returns the center of the hexagon at IJK coordinate c in 2D Hex
+// (Cartesian) coordinates on its face.
+func (c coordIJK) toHex2d() vec2d {
+	i := c.i - c.k
+	j := c.j - c.k
+
+	return vec2d{
+		x: float64(i) - 0.5*float64(j),
+		y: float64(j) * mSqrt3Half,
+	}
+}
+
+// --- Vec2d helpers ---
+
+// toCoordIJK converts a 2D Hex coordinate (Cartesian, on a face) into the
 // nearest hexagon's normalized IJK coordinate. The rounding logic selects the
 // containing hex cell, and the sign-folding handles the three 120°-symmetric
 // sectors when x or y is negative.
-func hex2dToCoordIJK(v vec2d) coordIJK {
+func (v vec2d) toCoordIJK() coordIJK {
 	var h coordIJK
 
 	h.k = 0
@@ -156,7 +286,7 @@ func hex2dToCoordIJK(v vec2d) coordIJK {
 	a2 := math.Abs(v.y)
 
 	x2 := a2 * mRSin60
-	x1 := a1 + x2/2.0 //nolint:mnd // hex grid rounding
+	x1 := a1 + x2/2.0
 
 	m1 := int(x1)
 	m2 := int(x2)
@@ -164,7 +294,7 @@ func hex2dToCoordIJK(v vec2d) coordIJK {
 	r1 := x1 - float64(m1)
 	r2 := x2 - float64(m2)
 
-	if r1 < 0.5 { //nolint:mnd // hex grid rounding
+	if r1 < 0.5 {
 		if r1 < 1.0/3.0 {
 			if r2 < (1.0+r1)/2.0 {
 				h.i = m1
@@ -180,7 +310,7 @@ func hex2dToCoordIJK(v vec2d) coordIJK {
 				h.j = m2 + 1
 			}
 
-			if (1.0-r1) <= r2 && r2 < (2.0*r1) { //nolint:mnd // hex grid rounding
+			if (1.0-r1) <= r2 && r2 < (2.0*r1) {
 				h.i = m1 + 1
 			} else {
 				h.i = m1
@@ -200,7 +330,7 @@ func hex2dToCoordIJK(v vec2d) coordIJK {
 				h.i = m1 + 1
 			}
 		} else {
-			if r2 < (r1 / 2.0) { //nolint:mnd // hex grid rounding
+			if r2 < (r1 / 2.0) {
 				h.i = m1 + 1
 				h.j = m2
 			} else {
@@ -212,80 +342,87 @@ func hex2dToCoordIJK(v vec2d) coordIJK {
 
 	if v.x < 0.0 {
 		if h.j%2 == 0 {
-			axisi := h.j / 2 //nolint:mnd // hex grid axis folding
+			axisi := h.j / 2
 			diff := h.i - axisi
-			h.i -= 2 * diff //nolint:mnd // hex grid axis folding
+			h.i -= 2 * diff
 		} else {
-			axisi := (h.j + 1) / 2 //nolint:mnd // hex grid axis folding
+			axisi := (h.j + 1) / 2
 			diff := h.i - axisi
-			h.i -= 2*diff + 1 //nolint:mnd // hex grid axis folding
+			h.i -= 2*diff + 1
 		}
 	}
 
 	if v.y < 0.0 {
-		h.i -= (2*h.j + 1) / 2 //nolint:mnd // hex grid axis folding
+		h.i -= (2*h.j + 1) / 2
 		h.j = -h.j
 	}
 
-	ijkNormalize(&h)
+	h.normalize()
 
 	return h
 }
 
-// upAp7 transforms an IJK coordinate to the next coarser resolution on the
-// Class II aperture-7 grid (the "up" direction), rounding to the nearest parent
-// cell and re-normalizing.
-func upAp7(ijk *coordIJK) {
-	i := ijk.i - ijk.k
-	j := ijk.j - ijk.k
-	ijk.i = int(math.Round(float64(3*i-j) * mOneSeventh))
-	ijk.j = int(math.Round(float64(i+2*j) * mOneSeventh))
-	ijk.k = 0
-	ijkNormalize(ijk)
+// mag returns the magnitude (length) of a 2D vector.
+func (v vec2d) mag() float64 {
+	return math.Sqrt(v.x*v.x + v.y*v.y)
 }
 
-// upAp7r transforms an IJK coordinate to the next coarser resolution on the
-// Class III (rotated) aperture-7 grid, rounding to the nearest parent cell and
-// re-normalizing.
-func upAp7r(ijk *coordIJK) {
-	i := ijk.i - ijk.k
-	j := ijk.j - ijk.k
-	ijk.i = int(math.Round(float64(2*i+j) * mOneSeventh))
-	ijk.j = int(math.Round(float64(3*j-i) * mOneSeventh))
-	ijk.k = 0
-	ijkNormalize(ijk)
+// intersect returns the intersection point of the line through v,p1 and the line
+// through p2,p3. The lines are assumed to intersect away from their endpoints.
+func (v vec2d) intersect(p1, p2, p3 vec2d) vec2d {
+	s1 := vec2d{x: p1.x - v.x, y: p1.y - v.y}
+	s2 := vec2d{x: p3.x - p2.x, y: p3.y - p2.y}
+
+	t := (s2.x*(v.y-p2.y) - s2.y*(v.x-p2.x)) /
+		(-s2.x*s1.y + s1.x*s2.y)
+
+	return vec2d{x: v.x + t*s1.x, y: v.y + t*s1.y}
 }
 
-// downAp7 transforms an IJK coordinate to the next finer resolution on the
-// Class II aperture-7 grid (the "down" direction, the exact inverse of upAp7),
-// then re-normalizes.
-func downAp7(ijk *coordIJK) {
-	i, j, k := ijk.i, ijk.j, ijk.k
-	ijk.i = 3*i + j //nolint:mnd // aperture-7 matrix coefficients
-	ijk.j = 3*j + k //nolint:mnd // aperture-7 matrix coefficients
-	ijk.k = i + 3*k //nolint:mnd // aperture-7 matrix coefficients
-	ijkNormalize(ijk)
+// almostEquals reports whether two 2D vectors are equal within fltEpsilon, used
+// to detect when an edge intersection coincides with an existing vertex.
+func (v vec2d) almostEquals(b vec2d) bool {
+	return math.Abs(v.x-b.x) < fltEpsilon && math.Abs(v.y-b.y) < fltEpsilon
 }
 
-// downAp7r transforms an IJK coordinate to the next finer resolution on the
-// Class III (rotated) aperture-7 grid (the inverse of upAp7r), then
-// re-normalizes.
-func downAp7r(ijk *coordIJK) {
-	i, j, k := ijk.i, ijk.j, ijk.k
-	ijk.i = 3*i + k //nolint:mnd // aperture-7 matrix coefficients
-	ijk.j = i + 3*j //nolint:mnd // aperture-7 matrix coefficients
-	ijk.k = j + 3*k //nolint:mnd // aperture-7 matrix coefficients
-	ijkNormalize(ijk)
-}
+// toVec3 converts a 2D Hex coordinate on a face into a 3D unit vector. It is the
+// inverse of the gnomonic projection: the radius is inverse-scaled per
+// resolution (and by a further third for substrate grids), the gnomonic scaling
+// is undone with atan, and the result is placed at the computed azimuth from the
+// face center. A point at the face center maps to the face center vector.
+func (v vec2d) toVec3(face, res int, substrate bool) vec3d {
+	r := v.mag()
+	if r < epsilon {
+		return faceCenterPoint[face]
+	}
 
-// unitIjkToDigit maps a unit IJK coordinate (one of the seven cells in a single
-// aperture-7 neighborhood: the center plus its six neighbors) to the
-// corresponding H3 digit (0–6) via a lookup table.
-func unitIjkToDigit(ijk coordIJK) int {
-	ijkNormalize(&ijk)
-	i, j, k := ijk.i, ijk.j, ijk.k
+	theta := math.Atan2(v.y, v.x)
 
-	return unitIjkToDigitLUT[i][j][k]
+	for range res {
+		r *= mRSqrt7
+	}
+
+	if substrate {
+		// Callers only project substrate grids at Class II (even) resolutions,
+		// so no Class III substrate adjustment is needed here.
+		r *= mOneThird
+	}
+
+	r *= res0UGnomonic
+	r = math.Atan(r)
+
+	if !substrate && isResClassIII(res) {
+		theta = posAngleRads(theta + mAP7RotRads)
+	}
+
+	theta = posAngleRads(faceAxesAzRadsCII[face][0] - theta)
+
+	north, east := faceCenterPoint[face].tangentBasis()
+	dir := north.linComb(math.Cos(theta), math.Sin(theta), east)
+	out := faceCenterPoint[face].linComb(math.Cos(r), math.Sin(r), dir)
+	out.normalize()
+
+	return out
 }
 
 // --- Digit rotation ---
@@ -334,33 +471,33 @@ func rotate60cw(digit int) int {
 
 // --- H3 index rotation ---
 
-// h3Rotate60ccw returns h with every resolution digit rotated 60°
+// rotate60ccw returns c with every resolution digit rotated 60°
 // counterclockwise, rotating the whole index about its base cell center.
-func h3Rotate60ccw(h Cell) Cell {
-	res := resolution(h)
+func (c Cell) rotate60ccw() Cell {
+	res := c.Resolution()
 	for r := 1; r <= res; r++ {
-		h = setIndexDigit(h, r, rotate60ccw(getIndexDigit(h, r)))
+		c = c.setIndexDigit(r, rotate60ccw(c.indexDigit(r)))
 	}
 
-	return h
+	return c
 }
 
-// h3Rotate60cw returns h with every resolution digit rotated 60° clockwise,
+// rotate60cw returns c with every resolution digit rotated 60° clockwise,
 // rotating the whole index about its base cell center.
-func h3Rotate60cw(h Cell) Cell {
-	res := resolution(h)
+func (c Cell) rotate60cw() Cell {
+	res := c.Resolution()
 	for r := 1; r <= res; r++ {
-		h = setIndexDigit(h, r, rotate60cw(getIndexDigit(h, r)))
+		c = c.setIndexDigit(r, rotate60cw(c.indexDigit(r)))
 	}
 
-	return h
+	return c
 }
 
-// h3LeadingNonZeroDigit returns the first (coarsest) non-center resolution digit
-// of h, or the center digit if every digit is the center.
-func h3LeadingNonZeroDigit(h Cell) int {
-	for r := 1; r <= resolution(h); r++ {
-		d := getIndexDigit(h, r)
+// leadingNonZeroDigit returns the first (coarsest) non-center resolution digit
+// of c, or the center digit if every digit is the center.
+func (c Cell) leadingNonZeroDigit() int {
+	for r := 1; r <= c.Resolution(); r++ {
+		d := c.indexDigit(r)
 		if d != centerDigit {
 			return d
 		}
@@ -369,37 +506,37 @@ func h3LeadingNonZeroDigit(h Cell) int {
 	return centerDigit
 }
 
-// h3RotatePent60ccw rotates h 60° counterclockwise about a pentagon base cell
+// rotatePent60ccw rotates c 60° counterclockwise about a pentagon base cell
 // center. Pentagons have a deleted k-axis subsequence, so as the leading digit
 // is first encountered the index is rotated an extra step when needed to skip
 // over the missing direction and keep the index canonical.
-func h3RotatePent60ccw(h Cell) Cell {
+func (c Cell) rotatePent60ccw() Cell {
 	foundFirstNonZero := false
 
-	for r := 1; r <= resolution(h); r++ {
-		h = setIndexDigit(h, r, rotate60ccw(getIndexDigit(h, r)))
+	for r := 1; r <= c.Resolution(); r++ {
+		c = c.setIndexDigit(r, rotate60ccw(c.indexDigit(r)))
 
-		if !foundFirstNonZero && getIndexDigit(h, r) != centerDigit {
+		if !foundFirstNonZero && c.indexDigit(r) != centerDigit {
 			foundFirstNonZero = true
 
-			if h3LeadingNonZeroDigit(h) == kAxesDigit {
-				h = h3Rotate60ccw(h)
+			if c.leadingNonZeroDigit() == kAxesDigit {
+				c = c.rotate60ccw()
 			}
 		}
 	}
 
-	return h
+	return c
 }
 
 // --- FaceIJK to H3 index ---
 
-// faceIjkToH3 encodes a face-centered IJK coordinate at the given resolution
-// into an H3 cell index. It sets the mode and resolution, walks from the finest
-// resolution up to the base cell (deriving each resolution digit from the offset
-// between a cell and its parent's center), then applies the base cell's
-// canonical rotations — with the extra pentagon handling for pentagon base
-// cells. It returns ErrFailed if the coordinate is out of the encodable range.
-func faceIjkToH3(fijk faceIJK, res int) (Cell, error) {
+// toH3 encodes a face-centered IJK coordinate at the given resolution into an H3
+// cell index. It sets the mode and resolution, walks from the finest resolution
+// up to the base cell (deriving each resolution digit from the offset between a
+// cell and its parent's center), then applies the base cell's canonical
+// rotations — with the extra pentagon handling for pentagon base cells. It
+// returns ErrFailed if the coordinate is out of the encodable range.
+func (fijk faceIJK) toH3(res int) (Cell, error) {
 	h := Cell(h3Init)
 	h |= Cell(cellMode) << modeOffset
 	h |= Cell(res) << resolutionOffset
@@ -424,14 +561,14 @@ func faceIjkToH3(fijk faceIJK, res int) (Cell, error) {
 
 		var lastCenter coordIJK
 
-		if (r+1)%2 == 1 { // class III
-			upAp7(ijk)
+		if isResClassIII(r + 1) {
+			ijk.upAp7()
 			lastCenter = *ijk
-			downAp7(&lastCenter)
+			lastCenter.downAp7()
 		} else {
-			upAp7r(ijk)
+			ijk.upAp7r()
 			lastCenter = *ijk
-			downAp7r(&lastCenter)
+			lastCenter.downAp7r()
 		}
 
 		diff := coordIJK{
@@ -439,8 +576,8 @@ func faceIjkToH3(fijk faceIJK, res int) (Cell, error) {
 			j: lastIJK.j - lastCenter.j,
 			k: lastIJK.k - lastCenter.k,
 		}
-		ijkNormalize(&diff)
-		h = setIndexDigit(h, r+1, unitIjkToDigit(diff))
+		diff.normalize()
+		h = h.setIndexDigit(r+1, diff.toDigit())
 	}
 
 	if fijkBC.coord.i > maxFaceCoord || fijkBC.coord.j > maxFaceCoord ||
@@ -455,23 +592,277 @@ func faceIjkToH3(fijk faceIJK, res int) (Cell, error) {
 	h |= Cell(baseCell) << baseCellOffset
 
 	if h3core.IsBaseCellPentagon[baseCell] {
-		if h3LeadingNonZeroDigit(h) == kAxesDigit {
+		if h.leadingNonZeroDigit() == kAxesDigit {
 			offsets := baseCellCWOffsetPent[baseCell]
 			if offsets[0] == fijkBC.face || offsets[1] == fijkBC.face {
-				h = h3Rotate60cw(h)
+				h = h.rotate60cw()
 			} else {
-				h = h3Rotate60ccw(h)
+				h = h.rotate60ccw()
 			}
 		}
 
 		for range numRots {
-			h = h3RotatePent60ccw(h)
+			h = h.rotatePent60ccw()
 		}
 	} else {
 		for range numRots {
-			h = h3Rotate60ccw(h)
+			h = h.rotate60ccw()
 		}
 	}
 
 	return h, nil
+}
+
+// --- FaceIJK to Vec3d / center point ---
+
+// toVec3 returns the 3D unit vector at the center of the cell addressed by fijk
+// at the given resolution.
+func (fijk faceIJK) toVec3(res int) vec3d {
+	return fijk.coord.toHex2d().toVec3(fijk.face, res, false)
+}
+
+// --- H3 index to FaceIJK ---
+
+// toFaceIjkWithInitializedFijk walks c's resolution digits down from its base
+// cell's home coordinate (passed in fijk) to the face-centered IJK coordinate of
+// the cell. It returns the updated address and whether the result may have
+// overflowed onto an adjacent face (possibleOverage), which the caller resolves.
+func (c Cell) toFaceIjkWithInitializedFijk(fijk faceIJK) (faceIJK, bool) {
+	res := c.Resolution()
+
+	// A center base cell hierarchy with no off-center digits stays on this face.
+	isCenter := fijk.coord.i == 0 && fijk.coord.j == 0 && fijk.coord.k == 0
+	possibleOverage := h3core.IsBaseCellPentagon[c.BaseCellNumber()] || (res != 0 && !isCenter)
+
+	ijk := fijk.coord
+
+	for r := 1; r <= res; r++ {
+		if isResClassIII(r) { // rotate ccw
+			ijk.downAp7()
+		} else { // Class II: rotate cw
+			ijk.downAp7r()
+		}
+
+		ijk = ijk.neighbor(c.indexDigit(r))
+	}
+
+	fijk.coord = ijk
+
+	return fijk, possibleOverage
+}
+
+// toFaceIjk converts an H3 cell into its FaceIJK address, resolving any overage
+// onto the correct adjacent icosahedron face (with the extra handling pentagon
+// base cells require). It returns ErrCellInvalid if the index's base cell is out
+// of range.
+func (c Cell) toFaceIjk() (faceIJK, error) {
+	baseCell := c.BaseCellNumber()
+	if baseCell >= numBaseCells {
+		return faceIJK{}, ErrCellInvalid
+	}
+
+	// Adjust for the pentagonal missing sequence: all of sub-sequence 5 needs to
+	// be rotated (and some of sub-sequence 4 is handled during overage below).
+	if h3core.IsBaseCellPentagon[baseCell] && c.leadingNonZeroDigit() == ikAxesDigit {
+		c = c.rotate60cw()
+	}
+
+	fijk, possibleOverage := c.toFaceIjkWithInitializedFijk(baseCellHomeFijk[baseCell])
+	if !possibleOverage {
+		return fijk, nil
+	}
+
+	origIJK := fijk.coord
+
+	// If we're in Class III, drop into the next finer Class II grid to adjust.
+	res := c.Resolution()
+	if isResClassIII(res) {
+		fijk.coord.downAp7r()
+
+		res++
+	}
+
+	// A pentagon base cell with a leading 4 digit requires special handling.
+	pentLeading4 := h3core.IsBaseCellPentagon[baseCell] && c.leadingNonZeroDigit() == iAxesDigit
+
+	var ov overage
+
+	fijk, ov = fijk.adjustOverageClassII(res, pentLeading4, false)
+	if ov != noOverage {
+		// A pentagon base cell can have secondary overages.
+		if h3core.IsBaseCellPentagon[baseCell] {
+			for {
+				var o overage
+
+				fijk, o = fijk.adjustOverageClassII(res, false, false)
+				if o == noOverage {
+					break
+				}
+			}
+		}
+
+		if res != c.Resolution() {
+			fijk.coord.upAp7r()
+		}
+	} else if res != c.Resolution() {
+		fijk.coord = origIJK
+	}
+
+	return fijk, nil
+}
+
+// adjustOverageClassII adjusts a FaceIJK address so it is expressed relative to
+// the correct icosahedron face when the coordinate has spilled past the edge of
+// its current face. pentLeading4 selects the pentagon missing-sequence fix-up,
+// and substrate selects the finer substrate grid used while building cell
+// boundaries. It returns the adjusted address and the overage classification.
+func (fijk faceIJK) adjustOverageClassII(res int, pentLeading4, substrate bool) (faceIJK, overage) {
+	ov := noOverage
+	ijk := fijk.coord
+
+	maxDim := maxDimByCIIres[res]
+	if substrate {
+		maxDim *= 3
+	}
+
+	sum := ijk.i + ijk.j + ijk.k
+
+	switch {
+	case substrate && sum == maxDim: // on the face edge
+		ov = faceEdge
+	case sum > maxDim: // overage onto an adjacent face
+		ov = newFace
+
+		var fijkOrient faceOrientIJK
+
+		switch {
+		case ijk.k > 0 && ijk.j > 0: // jk quadrant
+			fijkOrient = faceNeighbors[fijk.face][dirJK]
+		case ijk.k > 0: // ik quadrant
+			fijkOrient = faceNeighbors[fijk.face][dirKI]
+
+			if pentLeading4 {
+				// Translate to the pentagon center, rotate to skip the missing
+				// sequence, then translate back to the triangle center.
+				tmp := coordIJK{i: ijk.i - maxDim, j: ijk.j, k: ijk.k}.rotate60cw()
+				ijk = coordIJK{i: tmp.i + maxDim, j: tmp.j, k: tmp.k}
+			}
+		default: // ij quadrant
+			fijkOrient = faceNeighbors[fijk.face][dirIJ]
+		}
+
+		fijk.face = fijkOrient.face
+
+		for range fijkOrient.ccwRot60 {
+			ijk = ijk.rotate60ccw()
+		}
+
+		unitScale := unitScaleByCIIres[res]
+		if substrate {
+			unitScale *= 3
+		}
+
+		ijk = ijk.add(fijkOrient.translate.scale(unitScale))
+		ijk.normalize()
+
+		// Overage points on pentagon boundaries can end up on a face edge.
+		if substrate && ijk.i+ijk.j+ijk.k == maxDim {
+			ov = faceEdge
+		}
+	}
+
+	fijk.coord = ijk
+
+	return fijk, ov
+}
+
+// adjustPentVertOverage repeatedly applies the substrate overage adjustment to a
+// pentagon vertex until it no longer crosses onto a new face, returning the
+// final address and overage classification.
+func (fijk faceIJK) adjustPentVertOverage(res int) (faceIJK, overage) {
+	var ov overage
+
+	for {
+		fijk, ov = fijk.adjustOverageClassII(res, false, true)
+		if ov != newFace {
+			break
+		}
+	}
+
+	return fijk, ov
+}
+
+// toVerts returns the substrate FaceIJK addresses of a hexagon's six vertices,
+// along with the (possibly incremented) substrate resolution. The cell center is
+// moved into an aperture-33r substrate grid, and Class III cells get an extra
+// clockwise aperture-7 step to land on a Class II substrate.
+func (fijk faceIJK) toVerts(res int) (int, [numHexVerts]faceIJK) {
+	// Vertices of an origin-centered cell, listed ccw from the i-axis, in the
+	// Class II and Class III substrate grids respectively.
+	vertsCII := [numHexVerts]coordIJK{
+		{2, 1, 0}, {1, 2, 0}, {0, 2, 1}, {0, 1, 2}, {1, 0, 2}, {2, 0, 1},
+	}
+	vertsCIII := [numHexVerts]coordIJK{
+		{5, 4, 0}, {1, 5, 0}, {0, 5, 4}, {0, 1, 5}, {4, 0, 5}, {5, 0, 1},
+	}
+
+	verts := vertsCII
+	if isResClassIII(res) {
+		verts = vertsCIII
+	}
+
+	fijk.coord.downAp3()
+	fijk.coord.downAp3r()
+
+	if isResClassIII(res) {
+		fijk.coord.downAp7r()
+
+		res++
+	}
+
+	var out [numHexVerts]faceIJK
+
+	for i := range numHexVerts {
+		coord := fijk.coord.add(verts[i])
+		coord.normalize()
+		out[i] = faceIJK{face: fijk.face, coord: coord}
+	}
+
+	return res, out
+}
+
+// pentToVerts returns the substrate FaceIJK addresses of a pentagon's five
+// vertices, along with the (possibly incremented) substrate resolution, using
+// the same substrate construction as toVerts.
+func (fijk faceIJK) pentToVerts(res int) (int, [numPentVerts]faceIJK) {
+	vertsCII := [numPentVerts]coordIJK{
+		{2, 1, 0}, {1, 2, 0}, {0, 2, 1}, {0, 1, 2}, {1, 0, 2},
+	}
+	vertsCIII := [numPentVerts]coordIJK{
+		{5, 4, 0}, {1, 5, 0}, {0, 5, 4}, {0, 1, 5}, {4, 0, 5},
+	}
+
+	verts := vertsCII
+	if isResClassIII(res) {
+		verts = vertsCIII
+	}
+
+	fijk.coord.downAp3()
+	fijk.coord.downAp3r()
+
+	if isResClassIII(res) {
+		fijk.coord.downAp7r()
+
+		res++
+	}
+
+	var out [numPentVerts]faceIJK
+
+	for i := range numPentVerts {
+		coord := fijk.coord.add(verts[i])
+		coord.normalize()
+		out[i] = faceIJK{face: fijk.face, coord: coord}
+	}
+
+	return res, out
 }

--- a/x/h3go/faceijk_test.go
+++ b/x/h3go/faceijk_test.go
@@ -34,7 +34,7 @@ func TestVec3ToHex2dFaceCenter(t *testing.T) {
 	t.Parallel()
 
 	for f := range faceCenterPoint {
-		face, v := vec3ToHex2d(faceCenterPoint[f], 0)
+		face, v := faceCenterPoint[f].toHex2d(0)
 		if face != f {
 			t.Fatalf("face center %d: closest face = %d, want %d", f, face, f)
 		}
@@ -66,7 +66,7 @@ func TestFaceIjkToH3OutOfRange(t *testing.T) {
 
 			fijk := faceIJK{face: 0, coord: coordIJK{i: farCoord}}
 
-			got, err := faceIjkToH3(fijk, tt.giveRes)
+			got, err := fijk.toH3(tt.giveRes)
 			if !errors.Is(err, ErrFailed) {
 				t.Fatalf("faceIjkToH3 res %d: err = %v, want ErrFailed", tt.giveRes, err)
 			}

--- a/x/h3go/h3go.go
+++ b/x/h3go/h3go.go
@@ -32,6 +32,11 @@ type LatLng struct {
 	Lat, Lng float64
 }
 
+// CellBoundary is the ordered set of geographic vertices that outline a cell.
+// It never has more vertices than a cell has topological vertices plus its
+// distortion vertices.
+type CellBoundary []LatLng
+
 // Error codes. Messages mirror the cgo-backed h3 package so the two
 // implementations report equivalent failures.
 var (
@@ -54,6 +59,26 @@ type (
 		coord coordIJK
 	}
 	baseCellRotation struct{ baseCell, ccwRot60 int }
+
+	// faceOrientIJK describes how to transform an IJK coordinate from one
+	// icosahedron face into an adjacent face's coordinate system: the adjacent
+	// face, the res-0 translation, and the counterclockwise 60° rotation count.
+	faceOrientIJK struct {
+		face      int
+		translate coordIJK
+		ccwRot60  int
+	}
+
+	// overage classifies whether an IJK coordinate has spilled past the edge of
+	// its icosahedron face during the reverse projection.
+	overage int
+)
+
+// Overage classes returned by adjustOverageClassII.
+const (
+	noOverage overage = iota // on the original face
+	faceEdge                 // on a face edge (only occurs on substrate grids)
+	newFace                  // overage onto an adjacent face's interior
 )
 
 // Constants for the H3 index encoding and projection math.
@@ -61,15 +86,37 @@ const (
 	epsilon          = 1e-16
 	m2PI             = 2 * math.Pi
 	mSqrt7           = 2.6457513110645905905016157536392604257102
+	mRSqrt7          = 0.37796447300922722721451653623418006081576
 	mRSin60          = 1.1547005383792515290182975610039149112953
+	mSqrt3Half       = 0.8660254037844386467637231707529361834714
 	mOneSeventh      = 1.0 / 7.0
+	mOneThird        = 1.0 / 3.0
 	mAP7RotRads      = 0.333473172251832115336090755351601070065900389
 	invRes0UGnomonic = 2.61803398874989588842
+	res0UGnomonic    = 0.38196601125010500003
 	maxFaceCoord     = 2
 	numIcosaFaces    = 20
 
+	// numHexVerts and numPentVerts are the topological vertex counts of a
+	// hexagon and a pentagon cell, respectively.
+	numHexVerts  = 6
+	numPentVerts = 5
+
+	// fltEpsilon is the 32-bit float epsilon used to detect when a cell-boundary
+	// edge intersection coincides with an existing vertex (matching the cgo
+	// reference, which compares with FLT_EPSILON).
+	fltEpsilon = 1.1920928955078125e-07
+
+	// faceNeighbors quadrant indices: the direction from a face to the adjacent
+	// face that shares the corresponding pair of axes.
+	dirIJ = 1
+	dirKI = 2
+	dirJK = 3
+
 	// degsToRads converts degrees to radians by multiplying degrees by this constant.
 	degsToRads = math.Pi / 180.0
+	// radsToDegs converts radians to degrees by multiplying radians by this constant.
+	radsToDegs = 180.0 / math.Pi
 
 	// h3Init has all 15 digit slots set to 7 (invalid); mode/res/base cell are 0.
 	h3Init = 35184372088831
@@ -272,4 +319,311 @@ var faceIjkBaseCells = [20][3][3][3]baseCellRotation{
 		{{{118, 0}, {120, 0}, {115, 5}}, {{108, 1}, {114, 0}, {112, 0}}, {{92, 1}, {100, 0}, {102, 0}}},
 		{{{117, 0}, {121, 5}, {119, 5}}, {{109, 1}, {118, 0}, {120, 0}}, {{95, 1}, {108, 1}, {114, 0}}},
 	},
+}
+
+// unitVecs holds the IJK unit vector for each H3 digit direction, used to step
+// from a cell to its neighbor in that direction.
+var unitVecs = [7]coordIJK{
+	{0, 0, 0}, // center
+	{0, 0, 1}, // k axis
+	{0, 1, 0}, // j axis
+	{0, 1, 1}, // jk axis
+	{1, 0, 0}, // i axis
+	{1, 0, 1}, // ik axis
+	{1, 1, 0}, // ij axis
+}
+
+// faceNeighbors describes, for each icosahedron face, how to transform an IJK
+// coordinate into the adjacent face across each of the three axis-pair edges
+// (plus the identity transform for the face itself at index 0). It is indexed by
+// [face][dir] where dir is one of dirIJ, dirKI, dirJK.
+var faceNeighbors = [numIcosaFaces][4]faceOrientIJK{
+	{ // face 0
+		{0, coordIJK{0, 0, 0}, 0}, // central face
+		{4, coordIJK{2, 0, 2}, 1}, // ij quadrant
+		{1, coordIJK{2, 2, 0}, 5}, // ki quadrant
+		{5, coordIJK{0, 2, 2}, 3}, // jk quadrant
+	},
+	{ // face 1
+		{1, coordIJK{0, 0, 0}, 0},
+		{0, coordIJK{2, 0, 2}, 1},
+		{2, coordIJK{2, 2, 0}, 5},
+		{6, coordIJK{0, 2, 2}, 3},
+	},
+	{ // face 2
+		{2, coordIJK{0, 0, 0}, 0},
+		{1, coordIJK{2, 0, 2}, 1},
+		{3, coordIJK{2, 2, 0}, 5},
+		{7, coordIJK{0, 2, 2}, 3},
+	},
+	{ // face 3
+		{3, coordIJK{0, 0, 0}, 0},
+		{2, coordIJK{2, 0, 2}, 1},
+		{4, coordIJK{2, 2, 0}, 5},
+		{8, coordIJK{0, 2, 2}, 3},
+	},
+	{ // face 4
+		{4, coordIJK{0, 0, 0}, 0},
+		{3, coordIJK{2, 0, 2}, 1},
+		{0, coordIJK{2, 2, 0}, 5},
+		{9, coordIJK{0, 2, 2}, 3},
+	},
+	{ // face 5
+		{5, coordIJK{0, 0, 0}, 0},
+		{10, coordIJK{2, 2, 0}, 3},
+		{14, coordIJK{2, 0, 2}, 3},
+		{0, coordIJK{0, 2, 2}, 3},
+	},
+	{ // face 6
+		{6, coordIJK{0, 0, 0}, 0},
+		{11, coordIJK{2, 2, 0}, 3},
+		{10, coordIJK{2, 0, 2}, 3},
+		{1, coordIJK{0, 2, 2}, 3},
+	},
+	{ // face 7
+		{7, coordIJK{0, 0, 0}, 0},
+		{12, coordIJK{2, 2, 0}, 3},
+		{11, coordIJK{2, 0, 2}, 3},
+		{2, coordIJK{0, 2, 2}, 3},
+	},
+	{ // face 8
+		{8, coordIJK{0, 0, 0}, 0},
+		{13, coordIJK{2, 2, 0}, 3},
+		{12, coordIJK{2, 0, 2}, 3},
+		{3, coordIJK{0, 2, 2}, 3},
+	},
+	{ // face 9
+		{9, coordIJK{0, 0, 0}, 0},
+		{14, coordIJK{2, 2, 0}, 3},
+		{13, coordIJK{2, 0, 2}, 3},
+		{4, coordIJK{0, 2, 2}, 3},
+	},
+	{ // face 10
+		{10, coordIJK{0, 0, 0}, 0},
+		{5, coordIJK{2, 2, 0}, 3},
+		{6, coordIJK{2, 0, 2}, 3},
+		{15, coordIJK{0, 2, 2}, 3},
+	},
+	{ // face 11
+		{11, coordIJK{0, 0, 0}, 0},
+		{6, coordIJK{2, 2, 0}, 3},
+		{7, coordIJK{2, 0, 2}, 3},
+		{16, coordIJK{0, 2, 2}, 3},
+	},
+	{ // face 12
+		{12, coordIJK{0, 0, 0}, 0},
+		{7, coordIJK{2, 2, 0}, 3},
+		{8, coordIJK{2, 0, 2}, 3},
+		{17, coordIJK{0, 2, 2}, 3},
+	},
+	{ // face 13
+		{13, coordIJK{0, 0, 0}, 0},
+		{8, coordIJK{2, 2, 0}, 3},
+		{9, coordIJK{2, 0, 2}, 3},
+		{18, coordIJK{0, 2, 2}, 3},
+	},
+	{ // face 14
+		{14, coordIJK{0, 0, 0}, 0},
+		{9, coordIJK{2, 2, 0}, 3},
+		{5, coordIJK{2, 0, 2}, 3},
+		{19, coordIJK{0, 2, 2}, 3},
+	},
+	{ // face 15
+		{15, coordIJK{0, 0, 0}, 0},
+		{16, coordIJK{2, 0, 2}, 1},
+		{19, coordIJK{2, 2, 0}, 5},
+		{10, coordIJK{0, 2, 2}, 3},
+	},
+	{ // face 16
+		{16, coordIJK{0, 0, 0}, 0},
+		{17, coordIJK{2, 0, 2}, 1},
+		{15, coordIJK{2, 2, 0}, 5},
+		{11, coordIJK{0, 2, 2}, 3},
+	},
+	{ // face 17
+		{17, coordIJK{0, 0, 0}, 0},
+		{18, coordIJK{2, 0, 2}, 1},
+		{16, coordIJK{2, 2, 0}, 5},
+		{12, coordIJK{0, 2, 2}, 3},
+	},
+	{ // face 18
+		{18, coordIJK{0, 0, 0}, 0},
+		{19, coordIJK{2, 0, 2}, 1},
+		{17, coordIJK{2, 2, 0}, 5},
+		{13, coordIJK{0, 2, 2}, 3},
+	},
+	{ // face 19
+		{19, coordIJK{0, 0, 0}, 0},
+		{15, coordIJK{2, 0, 2}, 1},
+		{18, coordIJK{2, 2, 0}, 5},
+		{14, coordIJK{0, 2, 2}, 3},
+	},
+}
+
+// adjacentFaceDir gives the direction (dirIJ/dirKI/dirJK) from the origin face
+// to the destination face, in the origin face's coordinate system, 0 if they
+// are the same face, or -1 if the faces are not adjacent.
+var adjacentFaceDir = [numIcosaFaces][numIcosaFaces]int{
+	{0, dirKI, -1, -1, dirIJ, dirJK, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1}, // face 0
+	{dirIJ, 0, dirKI, -1, -1, -1, dirJK, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1}, // face 1
+	{-1, dirIJ, 0, dirKI, -1, -1, -1, dirJK, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1}, // face 2
+	{-1, -1, dirIJ, 0, dirKI, -1, -1, -1, dirJK, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1}, // face 3
+	{dirKI, -1, -1, dirIJ, 0, -1, -1, -1, -1, dirJK, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1}, // face 4
+	{dirJK, -1, -1, -1, -1, 0, -1, -1, -1, -1, dirIJ, -1, -1, -1, dirKI, -1, -1, -1, -1, -1}, // face 5
+	{-1, dirJK, -1, -1, -1, -1, 0, -1, -1, -1, dirKI, dirIJ, -1, -1, -1, -1, -1, -1, -1, -1}, // face 6
+	{-1, -1, dirJK, -1, -1, -1, -1, 0, -1, -1, -1, dirKI, dirIJ, -1, -1, -1, -1, -1, -1, -1}, // face 7
+	{-1, -1, -1, dirJK, -1, -1, -1, -1, 0, -1, -1, -1, dirKI, dirIJ, -1, -1, -1, -1, -1, -1}, // face 8
+	{-1, -1, -1, -1, dirJK, -1, -1, -1, -1, 0, -1, -1, -1, dirKI, dirIJ, -1, -1, -1, -1, -1}, // face 9
+	{-1, -1, -1, -1, -1, dirIJ, dirKI, -1, -1, -1, 0, -1, -1, -1, -1, dirJK, -1, -1, -1, -1}, // face 10
+	{-1, -1, -1, -1, -1, -1, dirIJ, dirKI, -1, -1, -1, 0, -1, -1, -1, -1, dirJK, -1, -1, -1}, // face 11
+	{-1, -1, -1, -1, -1, -1, -1, dirIJ, dirKI, -1, -1, -1, 0, -1, -1, -1, -1, dirJK, -1, -1}, // face 12
+	{-1, -1, -1, -1, -1, -1, -1, -1, dirIJ, dirKI, -1, -1, -1, 0, -1, -1, -1, -1, dirJK, -1}, // face 13
+	{-1, -1, -1, -1, -1, dirKI, -1, -1, -1, dirIJ, -1, -1, -1, -1, 0, -1, -1, -1, -1, dirJK}, // face 14
+	{-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, dirJK, -1, -1, -1, -1, 0, dirIJ, -1, -1, dirKI}, // face 15
+	{-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, dirJK, -1, -1, -1, dirKI, 0, dirIJ, -1, -1}, // face 16
+	{-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, dirJK, -1, -1, -1, dirKI, 0, dirIJ, -1}, // face 17
+	{-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, dirJK, -1, -1, -1, dirKI, 0, dirIJ}, // face 18
+	{-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, dirJK, dirIJ, -1, -1, dirKI, 0}, // face 19
+}
+
+// maxDimByCIIres is the maximum IJK dimension value, by Class II resolution,
+// used to detect overage past a face edge. Odd (Class III) entries are -1
+// because the overage check operates on Class II grids only.
+var maxDimByCIIres = [maxResolution + 2]int{
+	2, -1, 14, -1, 98, -1, 686, -1, 4802, -1, 33614, -1, 235298, -1, 1647086, -1, 11529602,
+}
+
+// unitScaleByCIIres is the unit-scale distance, by Class II resolution, used to
+// translate IJK coordinates onto an adjacent face. Odd entries are -1 for the
+// same reason as maxDimByCIIres.
+var unitScaleByCIIres = [maxResolution + 2]int{
+	1, -1, 7, -1, 49, -1, 343, -1, 2401, -1, 16807, -1, 117649, -1, 823543, -1, 5764801,
+}
+
+// baseCellHomeFijk maps each base cell to its "home" face and the normalized IJK
+// coordinates of its center on that face — the starting point for decoding a
+// cell back into a face-centered coordinate.
+var baseCellHomeFijk = [numBaseCells]faceIJK{
+	{1, coordIJK{1, 0, 0}},  // base cell 0
+	{2, coordIJK{1, 1, 0}},  // base cell 1
+	{1, coordIJK{0, 0, 0}},  // base cell 2
+	{2, coordIJK{1, 0, 0}},  // base cell 3
+	{0, coordIJK{2, 0, 0}},  // base cell 4
+	{1, coordIJK{1, 1, 0}},  // base cell 5
+	{1, coordIJK{0, 0, 1}},  // base cell 6
+	{2, coordIJK{0, 0, 0}},  // base cell 7
+	{0, coordIJK{1, 0, 0}},  // base cell 8
+	{2, coordIJK{0, 1, 0}},  // base cell 9
+	{1, coordIJK{0, 1, 0}},  // base cell 10
+	{1, coordIJK{0, 1, 1}},  // base cell 11
+	{3, coordIJK{1, 0, 0}},  // base cell 12
+	{3, coordIJK{1, 1, 0}},  // base cell 13
+	{11, coordIJK{2, 0, 0}}, // base cell 14
+	{4, coordIJK{1, 0, 0}},  // base cell 15
+	{0, coordIJK{0, 0, 0}},  // base cell 16
+	{6, coordIJK{0, 1, 0}},  // base cell 17
+	{0, coordIJK{0, 0, 1}},  // base cell 18
+	{2, coordIJK{0, 1, 1}},  // base cell 19
+	{7, coordIJK{0, 0, 1}},  // base cell 20
+	{2, coordIJK{0, 0, 1}},  // base cell 21
+	{0, coordIJK{1, 1, 0}},  // base cell 22
+	{6, coordIJK{0, 0, 1}},  // base cell 23
+	{10, coordIJK{2, 0, 0}}, // base cell 24
+	{6, coordIJK{0, 0, 0}},  // base cell 25
+	{3, coordIJK{0, 0, 0}},  // base cell 26
+	{11, coordIJK{1, 0, 0}}, // base cell 27
+	{4, coordIJK{1, 1, 0}},  // base cell 28
+	{3, coordIJK{0, 1, 0}},  // base cell 29
+	{0, coordIJK{0, 1, 1}},  // base cell 30
+	{4, coordIJK{0, 0, 0}},  // base cell 31
+	{5, coordIJK{0, 1, 0}},  // base cell 32
+	{0, coordIJK{0, 1, 0}},  // base cell 33
+	{7, coordIJK{0, 1, 0}},  // base cell 34
+	{11, coordIJK{1, 1, 0}}, // base cell 35
+	{7, coordIJK{0, 0, 0}},  // base cell 36
+	{10, coordIJK{1, 0, 0}}, // base cell 37
+	{12, coordIJK{2, 0, 0}}, // base cell 38
+	{6, coordIJK{1, 0, 1}},  // base cell 39
+	{7, coordIJK{1, 0, 1}},  // base cell 40
+	{4, coordIJK{0, 0, 1}},  // base cell 41
+	{3, coordIJK{0, 0, 1}},  // base cell 42
+	{3, coordIJK{0, 1, 1}},  // base cell 43
+	{4, coordIJK{0, 1, 0}},  // base cell 44
+	{6, coordIJK{1, 0, 0}},  // base cell 45
+	{11, coordIJK{0, 0, 0}}, // base cell 46
+	{8, coordIJK{0, 0, 1}},  // base cell 47
+	{5, coordIJK{0, 0, 1}},  // base cell 48
+	{14, coordIJK{2, 0, 0}}, // base cell 49
+	{5, coordIJK{0, 0, 0}},  // base cell 50
+	{12, coordIJK{1, 0, 0}}, // base cell 51
+	{10, coordIJK{1, 1, 0}}, // base cell 52
+	{4, coordIJK{0, 1, 1}},  // base cell 53
+	{12, coordIJK{1, 1, 0}}, // base cell 54
+	{7, coordIJK{1, 0, 0}},  // base cell 55
+	{11, coordIJK{0, 1, 0}}, // base cell 56
+	{10, coordIJK{0, 0, 0}}, // base cell 57
+	{13, coordIJK{2, 0, 0}}, // base cell 58
+	{10, coordIJK{0, 0, 1}}, // base cell 59
+	{11, coordIJK{0, 0, 1}}, // base cell 60
+	{9, coordIJK{0, 1, 0}},  // base cell 61
+	{8, coordIJK{0, 1, 0}},  // base cell 62
+	{6, coordIJK{2, 0, 0}},  // base cell 63
+	{8, coordIJK{0, 0, 0}},  // base cell 64
+	{9, coordIJK{0, 0, 1}},  // base cell 65
+	{14, coordIJK{1, 0, 0}}, // base cell 66
+	{5, coordIJK{1, 0, 1}},  // base cell 67
+	{16, coordIJK{0, 1, 1}}, // base cell 68
+	{8, coordIJK{1, 0, 1}},  // base cell 69
+	{5, coordIJK{1, 0, 0}},  // base cell 70
+	{12, coordIJK{0, 0, 0}}, // base cell 71
+	{7, coordIJK{2, 0, 0}},  // base cell 72
+	{12, coordIJK{0, 1, 0}}, // base cell 73
+	{10, coordIJK{0, 1, 0}}, // base cell 74
+	{9, coordIJK{0, 0, 0}},  // base cell 75
+	{13, coordIJK{1, 0, 0}}, // base cell 76
+	{16, coordIJK{0, 0, 1}}, // base cell 77
+	{15, coordIJK{0, 1, 1}}, // base cell 78
+	{15, coordIJK{0, 1, 0}}, // base cell 79
+	{16, coordIJK{0, 1, 0}}, // base cell 80
+	{14, coordIJK{1, 1, 0}}, // base cell 81
+	{13, coordIJK{1, 1, 0}}, // base cell 82
+	{5, coordIJK{2, 0, 0}},  // base cell 83
+	{8, coordIJK{1, 0, 0}},  // base cell 84
+	{14, coordIJK{0, 0, 0}}, // base cell 85
+	{9, coordIJK{1, 0, 1}},  // base cell 86
+	{14, coordIJK{0, 0, 1}}, // base cell 87
+	{17, coordIJK{0, 0, 1}}, // base cell 88
+	{12, coordIJK{0, 0, 1}}, // base cell 89
+	{16, coordIJK{0, 0, 0}}, // base cell 90
+	{17, coordIJK{0, 1, 1}}, // base cell 91
+	{15, coordIJK{0, 0, 1}}, // base cell 92
+	{16, coordIJK{1, 0, 1}}, // base cell 93
+	{9, coordIJK{1, 0, 0}},  // base cell 94
+	{15, coordIJK{0, 0, 0}}, // base cell 95
+	{13, coordIJK{0, 0, 0}}, // base cell 96
+	{8, coordIJK{2, 0, 0}},  // base cell 97
+	{13, coordIJK{0, 1, 0}}, // base cell 98
+	{17, coordIJK{1, 0, 1}}, // base cell 99
+	{19, coordIJK{0, 1, 0}}, // base cell 100
+	{14, coordIJK{0, 1, 0}}, // base cell 101
+	{19, coordIJK{0, 1, 1}}, // base cell 102
+	{17, coordIJK{0, 1, 0}}, // base cell 103
+	{13, coordIJK{0, 0, 1}}, // base cell 104
+	{17, coordIJK{0, 0, 0}}, // base cell 105
+	{16, coordIJK{1, 0, 0}}, // base cell 106
+	{9, coordIJK{2, 0, 0}},  // base cell 107
+	{15, coordIJK{1, 0, 1}}, // base cell 108
+	{15, coordIJK{1, 0, 0}}, // base cell 109
+	{18, coordIJK{0, 1, 1}}, // base cell 110
+	{18, coordIJK{0, 0, 1}}, // base cell 111
+	{19, coordIJK{0, 0, 1}}, // base cell 112
+	{17, coordIJK{1, 0, 0}}, // base cell 113
+	{19, coordIJK{0, 0, 0}}, // base cell 114
+	{18, coordIJK{0, 1, 0}}, // base cell 115
+	{18, coordIJK{1, 0, 1}}, // base cell 116
+	{19, coordIJK{2, 0, 0}}, // base cell 117
+	{19, coordIJK{1, 0, 0}}, // base cell 118
+	{18, coordIJK{0, 0, 0}}, // base cell 119
+	{19, coordIJK{1, 0, 1}}, // base cell 120
+	{18, coordIJK{1, 0, 0}}, // base cell 121
 }

--- a/x/h3go/hierarchy.go
+++ b/x/h3go/hierarchy.go
@@ -19,7 +19,7 @@ package h3go
 import "iter"
 
 // setResolution returns the cell with its resolution field set to res.
-func setResolution(c Cell, res int) Cell {
+func (c Cell) setResolution(res int) Cell {
 	c &= ^(Cell(resolutionMask) << resolutionOffset)
 	c |= Cell(res) << resolutionOffset
 
@@ -27,38 +27,38 @@ func setResolution(c Cell, res int) Cell {
 }
 
 // reservedBits returns the 3-bit reserved field of the index.
-func reservedBits(c Cell) int {
-	return int(c>>reservedOffset) & 0x7 //nolint:mnd // 3-bit reserved field
+func (c Cell) reservedBits() int {
+	return int(c>>reservedOffset) & 0x7
 }
 
 // zeroIndexDigits zeroes out index digits from start to end inclusive. It is a
 // no-op if start > end.
-func zeroIndexDigits(h Cell, start, end int) Cell {
+func (c Cell) zeroIndexDigits(start, end int) Cell {
 	if start > end {
-		return h
+		return c
 	}
 	// Mask with 0s in the [start, end] digit slots and 1s everywhere else.
 	digits := Cell(1)<<(perDigitOffset*(end-start+1)) - 1
 	mask := ^(digits << (perDigitOffset * (maxResolution - end)))
 
-	return h & mask
+	return c & mask
 }
 
 // hasChildAtRes reports whether childRes is a valid child resolution for c.
-func hasChildAtRes(c Cell, childRes int) bool {
-	parentRes := resolution(c)
+func (c Cell) hasChildAtRes(childRes int) bool {
+	parentRes := c.Resolution()
 	return childRes >= parentRes && childRes <= maxResolution
 }
 
-// cellToChildrenSize returns the exact number of children of c at childRes,
-// handling hexagons and pentagons.
-func cellToChildrenSize(c Cell, childRes int) (int64, error) {
-	if !hasChildAtRes(c, childRes) {
+// childrenSize returns the exact number of children of c at childRes, handling
+// hexagons and pentagons.
+func (c Cell) childrenSize(childRes int) (int64, error) {
+	if !c.hasChildAtRes(childRes) {
 		return 0, ErrResolutionDomain
 	}
 
-	n := childRes - resolution(c)
-	if isPentagonCell(c) {
+	n := childRes - c.Resolution()
+	if c.IsPentagon() {
 		return 1 + 5*(pow7[n]-1)/6, nil
 	}
 
@@ -67,7 +67,7 @@ func cellToChildrenSize(c Cell, childRes int) (int64, error) {
 
 // Parent returns the parent (or grandparent, etc.) of the cell at parentRes.
 func (c Cell) Parent(parentRes int) (Cell, error) {
-	childRes := resolution(c)
+	childRes := c.Resolution()
 	switch {
 	case parentRes < 0 || parentRes > maxResolution:
 		return 0, ErrResolutionDomain
@@ -77,9 +77,9 @@ func (c Cell) Parent(parentRes int) (Cell, error) {
 		return c, nil
 	}
 
-	parentH := setResolution(c, parentRes)
+	parentH := c.setResolution(parentRes)
 	for i := parentRes + 1; i <= childRes; i++ {
-		parentH = setIndexDigit(parentH, i, digitMask)
+		parentH = parentH.setIndexDigit(i, digitMask)
 	}
 
 	return parentH, nil
@@ -87,29 +87,29 @@ func (c Cell) Parent(parentRes int) (Cell, error) {
 
 // ImmediateParent returns the immediate parent of the cell.
 func (c Cell) ImmediateParent() (Cell, error) {
-	return c.Parent(resolution(c) - 1)
+	return c.Parent(c.Resolution() - 1)
 }
 
 // CenterChild returns the center child of the cell at childRes.
 func (c Cell) CenterChild(childRes int) (Cell, error) {
-	if !hasChildAtRes(c, childRes) {
+	if !c.hasChildAtRes(childRes) {
 		return 0, ErrResolutionDomain
 	}
-	h := zeroIndexDigits(c, resolution(c)+1, childRes)
+	h := c.zeroIndexDigits(c.Resolution()+1, childRes)
 
-	return setResolution(h, childRes), nil
+	return h.setResolution(childRes), nil
 }
 
 // Children returns the children (or grandchildren, etc.) of the cell at
 // childRes.
 func (c Cell) Children(childRes int) ([]Cell, error) {
-	size, err := cellToChildrenSize(c, childRes)
+	size, err := c.childrenSize(childRes)
 	if err != nil {
 		return nil, err
 	}
 
 	out := make([]Cell, 0, size)
-	for child := range childCells(c, childRes) {
+	for child := range c.childCells(childRes) {
 		out = append(out, child)
 	}
 
@@ -118,25 +118,25 @@ func (c Cell) Children(childRes int) ([]Cell, error) {
 
 // ImmediateChildren returns the immediate children of the cell.
 func (c Cell) ImmediateChildren() ([]Cell, error) {
-	return c.Children(resolution(c) + 1)
+	return c.Children(c.Resolution() + 1)
 }
 
-// childCells returns an iterator over the children of h at childRes. It yields
-// nothing for invalid input (h == 0, or childRes outside [resolution(h),
+// childCells returns an iterator over the children of c at childRes. It yields
+// nothing for invalid input (c == 0, or childRes outside [resolution(c),
 // maxResolution]).
-func childCells(h Cell, childRes int) iter.Seq[Cell] {
+func (c Cell) childCells(childRes int) iter.Seq[Cell] {
 	return func(yield func(Cell) bool) {
-		parentRes := resolution(h)
-		if h == 0 || childRes < parentRes || childRes > maxResolution {
+		parentRes := c.Resolution()
+		if c == 0 || childRes < parentRes || childRes > maxResolution {
 			return
 		}
 
-		cur := setResolution(zeroIndexDigits(h, parentRes+1, childRes), childRes)
+		cur := c.zeroIndexDigits(parentRes+1, childRes).setResolution(childRes)
 
 		// For pentagons the deleted K-axis (1) digit is skipped; the skip
 		// position moves left as the carry propagates from child toward parent.
 		skipDigit := -1
-		if isPentagonCell(cur) {
+		if cur.IsPentagon() {
 			skipDigit = childRes
 		}
 
@@ -145,7 +145,7 @@ func childCells(h Cell, childRes int) iter.Seq[Cell] {
 				return
 			}
 
-			cur = incrementResDigit(cur, childRes)
+			cur = cur.incrementResDigit(childRes)
 			done := false
 
 			for i := childRes; i >= parentRes; i-- {
@@ -156,15 +156,15 @@ func childCells(h Cell, childRes int) iter.Seq[Cell] {
 				}
 				// Skip the deleted 1 (K axis) digit for a pentagon's children:
 				// the first non-zero digit can never be 1.
-				if i == skipDigit && getIndexDigit(cur, i) == kAxesDigit {
-					cur = incrementResDigit(cur, i)
+				if i == skipDigit && cur.indexDigit(i) == kAxesDigit {
+					cur = cur.incrementResDigit(i)
 					skipDigit--
 
 					break
 				}
 
-				if getIndexDigit(cur, i) == invalidDigit {
-					cur = incrementResDigit(cur, i) // zeroes digit i and carries into i-1
+				if cur.indexDigit(i) == invalidDigit {
+					cur = cur.incrementResDigit(i) // zeroes digit i and carries into i-1
 				} else {
 					break
 				}
@@ -180,17 +180,17 @@ func childCells(h Cell, childRes int) iter.Seq[Cell] {
 // incrementResDigit returns h with the digit at res incremented by one. A digit
 // that overflows past 6 becomes invalidDigit (7); incrementing again zeroes it
 // and carries into the next coarser digit.
-func incrementResDigit(h Cell, res int) Cell {
+func (c Cell) incrementResDigit(res int) Cell {
 	var val Cell = 1
 	val <<= perDigitOffset * (maxResolution - res)
 
-	return h + val
+	return c + val
 }
 
 // validateChildPos returns an error if childPos is out of range for the children
 // of parent at childRes.
-func validateChildPos(childPos int64, parent Cell, childRes int) error {
-	maxChildCount, err := cellToChildrenSize(parent, childRes)
+func (c Cell) validateChildPos(childPos int64, childRes int) error {
+	maxChildCount, err := c.childrenSize(childRes)
 	if err != nil {
 		return err
 	}
@@ -205,23 +205,29 @@ func validateChildPos(childPos int64, parent Cell, childRes int) error {
 // CellToChildPos returns the position of cell within an ordered list of all
 // children of the cell's parent at parentRes.
 func CellToChildPos(cell Cell, parentRes int) (int, error) {
-	childRes := resolution(cell)
+	return cell.ChildPos(parentRes)
+}
+
+// ChildPos returns the position of the cell within an ordered list of all
+// children of the cell's parent at parentRes.
+func (c Cell) ChildPos(parentRes int) (int, error) {
+	childRes := c.Resolution()
 	// Getting the parent catches any resolution errors.
-	parent, err := cell.Parent(parentRes)
+	parent, err := c.Parent(parentRes)
 	if err != nil {
 		return 0, err
 	}
-	parentIsPentagon := isPentagonCell(parent)
+	parentIsPentagon := parent.IsPentagon()
 	var out int64
 
 	if parentIsPentagon {
 		// Pentagon parents skip the 1 digit, so the offsets differ from hexagons.
 		for res := childRes; res > parentRes; res-- {
 			// res-1 is always a valid parent resolution here, so it cannot error.
-			parent, _ = cell.Parent(res - 1)
-			parentIsPentagon = isPentagonCell(parent)
+			parent, _ = c.Parent(res - 1)
+			parentIsPentagon = parent.IsPentagon()
 
-			rawDigit := getIndexDigit(cell, res)
+			rawDigit := c.indexDigit(res)
 			if rawDigit == invalidDigit || (parentIsPentagon && rawDigit == kAxesDigit) {
 				return 0, ErrCellInvalid
 			}
@@ -234,7 +240,7 @@ func CellToChildPos(cell Cell, parentRes int) (int, error) {
 			if digit != centerDigit {
 				hexChildCount := pow7[childRes-res]
 				if parentIsPentagon {
-					out += 1 + 5*(hexChildCount-1)/6 //nolint:mnd // pentagon child-count formula
+					out += 1 + 5*(hexChildCount-1)/6
 				} else {
 					out += hexChildCount
 				}
@@ -244,7 +250,7 @@ func CellToChildPos(cell Cell, parentRes int) (int, error) {
 	} else {
 		// Hexagon offsets are simple powers of 7.
 		for res := childRes; res > parentRes; res-- {
-			digit := getIndexDigit(cell, res)
+			digit := c.indexDigit(res)
 			if digit == invalidDigit {
 				return 0, ErrCellInvalid
 			}
@@ -255,49 +261,49 @@ func CellToChildPos(cell Cell, parentRes int) (int, error) {
 	return int(out), nil
 }
 
-// ChildPos returns the position of the cell within an ordered list of all
-// children of the cell's parent at parentRes.
-func (c Cell) ChildPos(parentRes int) (int, error) {
-	return CellToChildPos(c, parentRes)
-}
-
 // ChildPosToCell returns the child of parent at the given position within an
 // ordered list of all children at childRes.
 func ChildPosToCell(position int, parent Cell, childRes int) (Cell, error) {
+	return parent.ChildPosToCell(position, childRes)
+}
+
+// ChildPosToCell returns the child cell at the given position within an ordered
+// list of all children at childRes.
+func (c Cell) ChildPosToCell(position int, childRes int) (Cell, error) {
 	if childRes < 0 || childRes > maxResolution {
 		return 0, ErrResolutionDomain
 	}
 
-	parentRes := resolution(parent)
+	parentRes := c.Resolution()
 	if childRes < parentRes {
 		return 0, ErrResolutionMismatch
 	}
 
-	if err := validateChildPos(int64(position), parent, childRes); err != nil {
+	if err := c.validateChildPos(int64(position), childRes); err != nil {
 		return 0, err
 	}
 	resOffset := childRes - parentRes
-	child := setResolution(parent, childRes)
+	child := c.setResolution(childRes)
 	idx := int64(position)
 
-	if isPentagonCell(parent) {
+	if c.IsPentagon() {
 		// Pentagon tiles skip the 1 digit, so the offsets differ.
 		inPent := true
 
 		for res := 1; res <= resOffset; res++ {
 			resWidth := pow7[resOffset-res]
 			if inPent {
-				pentWidth := 1 + 5*(resWidth-1)/6 //nolint:mnd // pentagon child-count formula
+				pentWidth := 1 + 5*(resWidth-1)/6
 				if idx < pentWidth {
-					child = setIndexDigit(child, parentRes+res, centerDigit)
+					child = child.setIndexDigit(parentRes+res, centerDigit)
 				} else {
 					idx -= pentWidth
 					inPent = false
-					child = setIndexDigit(child, parentRes+res, int(idx/resWidth)+2) //nolint:mnd // skip K axis
+					child = child.setIndexDigit(parentRes+res, int(idx/resWidth)+2)
 					idx %= resWidth
 				}
 			} else {
-				child = setIndexDigit(child, parentRes+res, int(idx/resWidth))
+				child = child.setIndexDigit(parentRes+res, int(idx/resWidth))
 				idx %= resWidth
 			}
 		}
@@ -305,18 +311,12 @@ func ChildPosToCell(position int, parent Cell, childRes int) (Cell, error) {
 		// Hexagon offsets are simple powers of 7.
 		for res := 1; res <= resOffset; res++ {
 			resWidth := pow7[resOffset-res]
-			child = setIndexDigit(child, parentRes+res, int(idx/resWidth))
+			child = child.setIndexDigit(parentRes+res, int(idx/resWidth))
 			idx %= resWidth
 		}
 	}
 
 	return child, nil
-}
-
-// ChildPosToCell returns the child cell at the given position within an ordered
-// list of all children at childRes.
-func (c Cell) ChildPosToCell(position int, childRes int) (Cell, error) {
-	return ChildPosToCell(position, c, childRes)
 }
 
 // UncompactCells expands a compacted set back to the full set of cells at res.
@@ -328,7 +328,7 @@ func UncompactCells(in []Cell, res int) ([]Cell, error) {
 			continue
 		}
 
-		size, err := cellToChildrenSize(c, res)
+		size, err := c.childrenSize(res)
 		if err != nil {
 			return nil, ErrResolutionMismatch
 		}
@@ -337,7 +337,7 @@ func UncompactCells(in []Cell, res int) ([]Cell, error) {
 	out := make([]Cell, 0, total)
 
 	for _, c := range in {
-		for child := range childCells(c, res) {
+		for child := range c.childCells(res) {
 			out = append(out, child)
 		}
 	}
@@ -352,7 +352,7 @@ func CompactCells(in []Cell) ([]Cell, error) {
 		return []Cell{}, nil
 	}
 
-	if resolution(in[0]) == 0 {
+	if in[0].Resolution() == 0 {
 		// No compaction possible at resolution 0.
 		out := make([]Cell, len(in))
 		copy(out, in)
@@ -364,7 +364,7 @@ func CompactCells(in []Cell) ([]Cell, error) {
 	var output []Cell
 
 	for len(remaining) > 0 {
-		parentRes := resolution(remaining[0]) - 1
+		parentRes := remaining[0].Resolution() - 1
 		if parentRes < 0 {
 			// Compacted all the way up to base cells.
 			output = append(output, remaining...)
@@ -378,7 +378,7 @@ func CompactCells(in []Cell) ([]Cell, error) {
 				continue
 			}
 
-			if reservedBits(c) != 0 {
+			if c.reservedBits() != 0 {
 				return nil, ErrCellInvalid
 			}
 
@@ -392,7 +392,7 @@ func CompactCells(in []Cell) ([]Cell, error) {
 			}
 
 			counts[parent]++
-			if counts[parent] > fullChildCount(parent) {
+			if counts[parent] > parent.fullChildCount() {
 				return nil, ErrDuplicateInput
 			}
 		}
@@ -400,7 +400,7 @@ func CompactCells(in []Cell) ([]Cell, error) {
 		var next []Cell
 
 		for _, parent := range order {
-			if counts[parent] == fullChildCount(parent) {
+			if counts[parent] == parent.fullChildCount() {
 				compactable[parent] = true
 				next = append(next, parent)
 			}
@@ -432,8 +432,8 @@ const (
 // fullChildCount returns the number of immediate children that make a cell's
 // child set complete: 6 for pentagons (the K-axis child is deleted), 7 for
 // hexagons.
-func fullChildCount(c Cell) int {
-	if isPentagonCell(c) {
+func (c Cell) fullChildCount() int {
+	if c.IsPentagon() {
 		return numPentChildren
 	}
 

--- a/x/h3go/hierarchy_test.go
+++ b/x/h3go/hierarchy_test.go
@@ -49,7 +49,7 @@ func TestCellToChildrenSizeKnown(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := cellToChildrenSize(tt.giveCell, tt.giveChildRes)
+			got, err := tt.giveCell.childrenSize(tt.giveChildRes)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -321,7 +321,7 @@ func TestChildCellsInvalidInput(t *testing.T) {
 			t.Parallel()
 
 			count := 0
-			for range childCells(tt.giveCell, tt.giveRes) {
+			for range tt.giveCell.childCells(tt.giveRes) {
 				count++
 			}
 
@@ -338,7 +338,7 @@ func TestChildCellsEarlyBreak(t *testing.T) {
 	t.Parallel()
 
 	count := 0
-	for range childCells(setIndexCell(5, 0, 0), 7) {
+	for range setIndexCell(5, 0, 0).childCells(7) {
 		count++
 		if count == 1 {
 			break
@@ -355,7 +355,7 @@ func TestChildCellsEarlyBreak(t *testing.T) {
 func TestValidateChildPosResError(t *testing.T) {
 	t.Parallel()
 
-	if err := validateChildPos(0, setIndexCell(5, 0, 0), -1); err == nil {
+	if err := setIndexCell(5, 0, 0).validateChildPos(0, -1); err == nil {
 		t.Fatal("validateChildPos with invalid resolution should error")
 	}
 }
@@ -369,7 +369,7 @@ func TestCellToChildPosInvalidDigit(t *testing.T) {
 		t.Parallel()
 
 		// Pentagon base cell 4, res-2, with a deleted K-axis (1) digit.
-		cell := setIndexDigit(setH3Index(2, 4, centerDigit), 2, kAxesDigit)
+		cell := setH3Index(2, 4, centerDigit).setIndexDigit(2, kAxesDigit)
 		if _, err := CellToChildPos(cell, 1); !errors.Is(err, ErrCellInvalid) {
 			t.Fatalf("CellToChildPos(pentagon k-axis): got %v, want ErrCellInvalid", err)
 		}
@@ -379,7 +379,7 @@ func TestCellToChildPosInvalidDigit(t *testing.T) {
 		t.Parallel()
 
 		// Hexagon base cell 0, res-2, with an unused (7) digit in a used slot.
-		cell := setIndexDigit(setH3Index(2, 0, centerDigit), 2, invalidDigit)
+		cell := setH3Index(2, 0, centerDigit).setIndexDigit(2, invalidDigit)
 		if _, err := CellToChildPos(cell, 1); !errors.Is(err, ErrCellInvalid) {
 			t.Fatalf("CellToChildPos(hexagon invalid digit): got %v, want ErrCellInvalid", err)
 		}

--- a/x/h3go/index.go
+++ b/x/h3go/index.go
@@ -68,28 +68,18 @@ var pow7 = [maxResolution + 1]int64{
 	4747561509943,
 }
 
-// resolution returns the resolution of the index.
-func resolution(c Cell) int {
-	return int(c>>resolutionOffset) & resolutionMask
-}
-
 // mode returns the H3 index mode (cell, directed edge, or vertex).
-func mode(c Cell) int {
+func (c Cell) mode() int {
 	return int(c>>modeOffset) & modeMask
 }
 
-// baseCellNumber returns the base cell number (0-121) of the index.
-func baseCellNumber(c Cell) int {
-	return int(c>>baseCellOffset) & baseCellMask
-}
-
-// getIndexDigit returns the indexing digit of the index at res.
-func getIndexDigit(c Cell, res int) int {
+// indexDigit returns the indexing digit of the index at res.
+func (c Cell) indexDigit(res int) int {
 	return int((c >> ((maxResolution - res) * perDigitOffset)) & digitMask)
 }
 
 // setIndexDigit returns the index with the digit at res set to digit.
-func setIndexDigit(c Cell, res, digit int) Cell {
+func (c Cell) setIndexDigit(res, digit int) Cell {
 	shift := (maxResolution - res) * perDigitOffset
 	c &= ^(Cell(digitMask) << shift)
 	c |= Cell(digit) << shift
@@ -100,13 +90,13 @@ func setIndexDigit(c Cell, res, digit int) Cell {
 // BaseCellNumber returns the integer ID (0-121) of the base cell the cell
 // belongs to.
 func BaseCellNumber(c Cell) int {
-	return baseCellNumber(c)
+	return c.BaseCellNumber()
 }
 
 // BaseCellNumber returns the integer ID (0-121) of the base cell the cell
 // belongs to.
 func (c Cell) BaseCellNumber() int {
-	return baseCellNumber(c)
+	return int(c>>baseCellOffset) & baseCellMask
 }
 
 // NumCells returns the number of cells at the given resolution. Resolutions
@@ -116,28 +106,40 @@ func NumCells(res int) int {
 		return 0
 	}
 	// See h3api.h for the formula derivation.
-	return int(2 + 120*pow7[res]) //nolint:mnd // math formula
+	return int(2 + 120*pow7[res])
 }
 
 // Resolution returns the resolution of the cell.
 func (c Cell) Resolution() int {
-	return resolution(c)
+	return int(c>>resolutionOffset) & resolutionMask
+}
+
+// isResClassIII reports whether a resolution is Class III. Odd resolutions are
+// Class III; even resolutions are Class II.
+func isResClassIII(res int) bool {
+	return res%2 == 1
 }
 
 // IsResClassIII reports whether the cell is in a Class III resolution. Odd
 // resolutions are Class III; even resolutions are Class II.
 func (c Cell) IsResClassIII() bool {
-	return resolution(c)%2 == 1
+	return isResClassIII(c.Resolution())
 }
 
-// IsPentagon reports whether the cell is a pentagon.
+// IsPentagon reports whether the cell is a pentagon: its base cell is a pentagon
+// and it has no leading non-zero digit.
 func (c Cell) IsPentagon() bool {
-	return isPentagonCell(c)
-}
+	if !h3core.IsBaseCellPentagon[c.BaseCellNumber()] {
+		return false
+	}
 
-// IsValid reports whether the cell is a valid H3 cell (hexagon or pentagon).
-func (c Cell) IsValid() bool {
-	return c != 0 && isValidCell(c)
+	for r := 1; r <= c.Resolution(); r++ {
+		if c.indexDigit(r) != centerDigit {
+			return false
+		}
+	}
+
+	return true
 }
 
 // IndexDigit returns the indexing digit of the cell at res, which starts at 1
@@ -147,28 +149,17 @@ func (c Cell) IndexDigit(res int) (int, error) {
 		return 0, ErrResolutionDomain
 	}
 
-	return getIndexDigit(c, res), nil
+	return c.indexDigit(res), nil
 }
 
-// isPentagonCell reports whether the cell is a pentagon: its base cell is a
-// pentagon and it has no leading non-zero digit.
-func isPentagonCell(c Cell) bool {
-	if !h3core.IsBaseCellPentagon[baseCellNumber(c)] {
+// IsValid reports whether the cell is a valid H3 cell (hexagon or pentagon). It
+// looks for bit patterns that would disqualify an index from being a valid cell,
+// exiting early.
+func (c Cell) IsValid() bool {
+	if c == 0 {
 		return false
 	}
 
-	for r := 1; r <= resolution(c); r++ {
-		if getIndexDigit(c, r) != centerDigit {
-			return false
-		}
-	}
-
-	return true
-}
-
-// isValidCell looks for bit patterns that would disqualify an index from being
-// a valid cell, exiting early.
-func isValidCell(c Cell) bool {
 	//nolint:gosec // an H3 index is a 64-bit value; int64->uint64 is a lossless reinterpretation.
 	h := uint64(c)
 	// Top 8 bits: high=0, mode=1 (cell), reserved=0 => 0b00001000.
@@ -176,12 +167,12 @@ func isValidCell(c Cell) bool {
 		return false
 	}
 
-	bc := baseCellNumber(c)
+	bc := c.BaseCellNumber()
 	if bc >= numBaseCells {
 		return false
 	}
 
-	res := resolution(c)
+	res := c.Resolution()
 	if hasAny7UptoRes(h, res) {
 		return false
 	}

--- a/x/h3go/index_test.go
+++ b/x/h3go/index_test.go
@@ -29,7 +29,7 @@ func TestIsValidCellBitPatterns(t *testing.T) {
 
 		for m := 0; m <= 0xf; m++ {
 			h := Cell(h3Init) | Cell(m)<<modeOffset
-			if got, want := isValidCell(h), m == cellMode; got != want {
+			if got, want := h.IsValid(), m == cellMode; got != want {
 				t.Fatalf("mode %d: isValidCell = %v, want %v", m, got, want)
 			}
 		}
@@ -40,7 +40,7 @@ func TestIsValidCellBitPatterns(t *testing.T) {
 
 		for i := 0; i < 8; i++ {
 			h := Cell(h3Init) | Cell(cellMode)<<modeOffset | Cell(i)<<reservedOffset
-			if got, want := isValidCell(h), i == 0; got != want {
+			if got, want := h.IsValid(), i == 0; got != want {
 				t.Fatalf("reserved bits %d: isValidCell = %v, want %v", i, got, want)
 			}
 		}
@@ -53,7 +53,7 @@ func TestIsValidCellBitPatterns(t *testing.T) {
 		highBit <<= bitSize - 1
 
 		h := Cell(h3Init) | Cell(cellMode)<<modeOffset | highBit
-		if isValidCell(h) {
+		if h.IsValid() {
 			t.Fatal("isValidCell should fail when the high bit is set")
 		}
 	})
@@ -62,7 +62,7 @@ func TestIsValidCellBitPatterns(t *testing.T) {
 		t.Parallel()
 
 		h := setH3Index(0, numBaseCells, centerDigit)
-		if isValidCell(h) {
+		if h.IsValid() {
 			t.Fatal("isValidCell should fail for an out-of-range base cell")
 		}
 	})
@@ -71,8 +71,8 @@ func TestIsValidCellBitPatterns(t *testing.T) {
 		t.Parallel()
 
 		// res 1 with the default all-7 digits: digit 1 is invalid.
-		h := setResolution(Cell(h3Init)|Cell(cellMode)<<modeOffset, 1)
-		if isValidCell(h) {
+		h := (Cell(h3Init) | Cell(cellMode)<<modeOffset).setResolution(1)
+		if h.IsValid() {
 			t.Fatal("isValidCell should fail when a used digit is 7")
 		}
 	})
@@ -82,7 +82,7 @@ func TestIsValidCellBitPatterns(t *testing.T) {
 
 		// A cell in a deleted subsequence of pentagon base cell 4.
 		h := setH3Index(1, 4, kAxesDigit)
-		if isValidCell(h) {
+		if h.IsValid() {
 			t.Fatal("isValidCell should fail on a pentagon deleted subsequence")
 		}
 	})
@@ -92,13 +92,13 @@ func TestIsValidCellBitPatterns(t *testing.T) {
 
 		for res := 1; res <= maxResolution; res++ {
 			pent := setH3Index(res, 4, centerDigit) // pentagon center child
-			if !isValidCell(pent) {
+			if !pent.IsValid() {
 				t.Fatalf("res %d: pentagon center child should be valid", res)
 			}
 
 			for d := 0; d <= 6; d++ {
-				h := setIndexDigit(pent, res, d)
-				if got, want := isValidCell(h), d != kAxesDigit; got != want {
+				h := pent.setIndexDigit(res, d)
+				if got, want := h.IsValid(), d != kAxesDigit; got != want {
 					t.Fatalf("res %d digit %d: isValidCell = %v, want %v", res, d, got, want)
 				}
 			}
@@ -110,8 +110,8 @@ func TestIsValidCellBitPatterns(t *testing.T) {
 
 		// A res-0 cell with an unused digit slot set to something other than 7
 		// is invalid: every digit beyond the resolution must be 7.
-		h := setIndexDigit(setH3Index(0, 0, centerDigit), 5, centerDigit)
-		if isValidCell(h) {
+		h := setH3Index(0, 0, centerDigit).setIndexDigit(5, centerDigit)
+		if h.IsValid() {
 			t.Fatal("isValidCell should fail when an unused digit is not 7")
 		}
 	})

--- a/x/h3go/latlng.go
+++ b/x/h3go/latlng.go
@@ -32,9 +32,24 @@ func LatLngToCell(latLng LatLng, res int) (Cell, error) {
 	lat := latLng.Lat * degsToRads
 	lng := latLng.Lng * degsToRads
 	v := latLngToVec3(lat, lng)
-	fijk := vec3ToFaceIjk(v, res)
+	fijk := v.toFaceIjk(res)
 
-	return faceIjkToH3(fijk, res)
+	return fijk.toH3(res)
+}
+
+// CellToLatLng returns the geographic center point of a cell in degrees.
+func CellToLatLng(c Cell) (LatLng, error) {
+	return c.LatLng()
+}
+
+// LatLng returns the geographic center point of the cell in degrees.
+func (c Cell) LatLng() (LatLng, error) {
+	fijk, err := c.toFaceIjk()
+	if err != nil {
+		return LatLng{}, err
+	}
+
+	return fijk.toVec3(c.Resolution()).toLatLng(), nil
 }
 
 // --- Vec3d math ---
@@ -49,28 +64,38 @@ func latLngToVec3(lat, lng float64) vec3d {
 	}
 }
 
-func vec3Dot(a, b vec3d) float64 {
-	return a.x*b.x + a.y*b.y + a.z*b.z
-}
-
-func vec3Cross(a, b vec3d) vec3d {
-	return vec3d{
-		x: a.y*b.z - a.z*b.y,
-		y: a.z*b.x - a.x*b.z,
-		z: a.x*b.y - a.y*b.x,
+// toLatLng converts a 3D unit vector on the sphere into a geographic coordinate
+// in degrees.
+func (v vec3d) toLatLng() LatLng {
+	return LatLng{
+		Lat: radsToDegs * math.Asin(v.z),
+		Lng: radsToDegs * math.Atan2(v.y, v.x),
 	}
 }
 
-func vec3LinComb(a float64, v1 vec3d, b float64, v2 vec3d) vec3d {
+func (v vec3d) dot(b vec3d) float64 {
+	return v.x*b.x + v.y*b.y + v.z*b.z
+}
+
+func (v vec3d) cross(b vec3d) vec3d {
 	return vec3d{
-		x: a*v1.x + b*v2.x,
-		y: a*v1.y + b*v2.y,
-		z: a*v1.z + b*v2.z,
+		x: v.y*b.z - v.z*b.y,
+		y: v.z*b.x - v.x*b.z,
+		z: v.x*b.y - v.y*b.x,
 	}
 }
 
-func vec3Normalize(v *vec3d) {
-	sq := vec3Dot(*v, *v)
+// linComb returns the linear combination scaleA·v + scaleB·other.
+func (v vec3d) linComb(scaleA, scaleB float64, other vec3d) vec3d {
+	return vec3d{
+		x: scaleA*v.x + scaleB*other.x,
+		y: scaleA*v.y + scaleB*other.y,
+		z: scaleA*v.z + scaleB*other.z,
+	}
+}
+
+func (v *vec3d) normalize() {
+	sq := v.dot(*v)
 
 	s := 0.0
 	if sq > 0 {
@@ -82,8 +107,8 @@ func vec3Normalize(v *vec3d) {
 	v.z *= s
 }
 
-func vec3DistSq(a, b vec3d) float64 {
-	d := vec3LinComb(1.0, a, -1.0, b)
+func (v vec3d) distSq(b vec3d) float64 {
+	d := v.linComb(1.0, -1.0, b)
 
-	return vec3Dot(d, d)
+	return d.dot(d)
 }

--- a/x/h3go/latlng_test.go
+++ b/x/h3go/latlng_test.go
@@ -120,6 +120,35 @@ func TestLatLngToCellProjectionSweep(t *testing.T) {
 	}
 }
 
+// TestCellReverseMethods covers the Cell.LatLng and Cell.Boundary method
+// wrappers, which delegate to CellToLatLng and CellToBoundary.
+func TestCellReverseMethods(t *testing.T) {
+	t.Parallel()
+
+	cell, err := LatLngToCell(LatLng{Lat: 37.7749, Lng: -122.4194}, 9)
+	if err != nil {
+		t.Fatalf("LatLngToCell: %v", err)
+	}
+
+	ll, err := cell.LatLng()
+	if err != nil {
+		t.Fatalf("Cell.LatLng(%015x): %v", uint64(cell), err)
+	}
+
+	if got, err := LatLngToCell(ll, cell.Resolution()); err != nil || got != cell {
+		t.Fatalf("Cell.LatLng round trip: got %015x err %v, want %015x", uint64(got), err, uint64(cell))
+	}
+
+	boundary, err := cell.Boundary()
+	if err != nil {
+		t.Fatalf("Cell.Boundary(%015x): %v", uint64(cell), err)
+	}
+
+	if len(boundary) != numHexVerts {
+		t.Fatalf("Cell.Boundary(%015x): %d vertices, want %d", uint64(cell), len(boundary), numHexVerts)
+	}
+}
+
 // assertValidAtRes fails unless LatLngToCell returns a valid cell at res.
 func assertValidAtRes(t *testing.T, lat, lng float64, res int) {
 	t.Helper()
@@ -135,5 +164,58 @@ func assertValidAtRes(t *testing.T, lat, lng float64, res int) {
 
 	if c.Resolution() != res {
 		t.Fatalf("LatLngToCell(%v, %v, %d) = %015x: resolution %d", lat, lng, res, uint64(c), c.Resolution())
+	}
+}
+
+// TestCellToLatLngRoundTrip asserts the strong invariant that re-encoding a
+// cell's own center point at the same resolution yields the original cell. This
+// exercises the whole reverse projection (h3ToFaceIjk, faceIjkToVec3,
+// hex2dToVec3) against the forward pipeline over a rich corpus of base cells,
+// hexagons, and pentagons, including pentagon descendants that reach the
+// pentagon rotation and overage paths.
+func TestCellToLatLngRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for _, c := range reverseCorpus(t) {
+		ll, err := CellToLatLng(c)
+		if err != nil {
+			t.Fatalf("CellToLatLng(%015x): %v", uint64(c), err)
+		}
+
+		if math.IsNaN(ll.Lat) || math.IsNaN(ll.Lng) ||
+			ll.Lat < -90 || ll.Lat > 90 || ll.Lng < -180 || ll.Lng > 180 {
+			t.Fatalf("CellToLatLng(%015x) = %+v: out of range", uint64(c), ll)
+		}
+
+		got, err := LatLngToCell(ll, c.Resolution())
+		if err != nil {
+			t.Fatalf("LatLngToCell(%+v, %d): %v", ll, c.Resolution(), err)
+		}
+
+		if got != c {
+			t.Fatalf("round trip for %015x: center %+v re-encoded to %015x", uint64(c), ll, uint64(got))
+		}
+	}
+}
+
+// TestCellToLatLngInvalidBaseCell covers the invalid-base-cell error branch of
+// the reverse projection, which is unreachable from a validly constructed cell.
+func TestCellToLatLngInvalidBaseCell(t *testing.T) {
+	t.Parallel()
+
+	bad := Cell(h3Init) | Cell(cellMode)<<modeOffset | Cell(numBaseCells)<<baseCellOffset
+
+	if _, err := CellToLatLng(bad); !errors.Is(err, ErrCellInvalid) {
+		t.Fatalf("CellToLatLng(%015x): got %v, want %v", uint64(bad), err, ErrCellInvalid)
+	}
+}
+
+// TestCellToLatLngInvalidIndex is the regression matching the cgo reference: an
+// all-ones index (whose base cell field is out of range) is rejected.
+func TestCellToLatLngInvalidIndex(t *testing.T) {
+	t.Parallel()
+
+	if _, err := CellToLatLng(Cell(0x7fffffffffffffff)); !errors.Is(err, ErrCellInvalid) {
+		t.Fatalf("CellToLatLng(0x7fffffffffffffff): got %v, want %v", err, ErrCellInvalid)
 	}
 }

--- a/x/h3go/paritytest/reverse_test.go
+++ b/x/h3go/paritytest/reverse_test.go
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package paritytest
+
+import (
+	"math"
+	"testing"
+
+	"github.com/uber/h3-go/v4"
+	"github.com/uber/h3-go/v4/x/h3go"
+)
+
+// llTolerance is the maximum allowed difference, in degrees, between the pure-Go
+// and cgo geographic coordinates. Both implementations run the same arithmetic,
+// so results agree to within floating-point rounding.
+const llTolerance = 1e-9
+
+// TestCellToLatLngMatchesCgo asserts the pure-Go cell center matches the
+// cgo-backed reference for every cell in the shared corpus.
+func TestCellToLatLngMatchesCgo(t *testing.T) {
+	t.Parallel()
+
+	for _, ref := range referenceCorpus(t) {
+		want, wErr := h3.CellToLatLng(ref)
+		got, gErr := h3go.CellToLatLng(h3goCell(ref))
+
+		if !bothErr(wErr, gErr) {
+			t.Fatalf("CellToLatLng(%015x) error mismatch: cgo=%v h3go=%v", uint64(ref), wErr, gErr)
+		}
+
+		assertSameLatLng(t, got.Lat, got.Lng, want.Lat, want.Lng, uint64(ref))
+	}
+}
+
+// TestCellToBoundaryMatchesCgo asserts the pure-Go cell boundary matches the
+// cgo-backed reference, vertex for vertex, for every cell in the shared corpus.
+func TestCellToBoundaryMatchesCgo(t *testing.T) {
+	t.Parallel()
+
+	for _, ref := range referenceCorpus(t) {
+		want, wErr := h3.CellToBoundary(ref)
+		got, gErr := h3go.CellToBoundary(h3goCell(ref))
+
+		if !bothErr(wErr, gErr) {
+			t.Fatalf("CellToBoundary(%015x) error mismatch: cgo=%v h3go=%v", uint64(ref), wErr, gErr)
+		}
+
+		if len(got) != len(want) {
+			t.Fatalf("CellToBoundary(%015x): %d vertices, want %d", uint64(ref), len(got), len(want))
+		}
+
+		for i := range want {
+			assertSameLatLng(t, got[i].Lat, got[i].Lng, want[i].Lat, want[i].Lng, uint64(ref))
+		}
+	}
+}
+
+// assertSameLatLng fails if two coordinates differ by more than llTolerance.
+func assertSameLatLng(t *testing.T, gotLat, gotLng, wantLat, wantLng float64, cell uint64) {
+	t.Helper()
+
+	if math.Abs(gotLat-wantLat) > llTolerance || math.Abs(gotLng-wantLng) > llTolerance {
+		t.Fatalf("cell %015x: got {%v %v}, want {%v %v}", cell, gotLat, gotLng, wantLat, wantLng)
+	}
+}

--- a/x/h3go/sets.go
+++ b/x/h3go/sets.go
@@ -23,11 +23,11 @@ import "github.com/uber/h3-go/v4/internal/h3core"
 func setH3Index(res, baseCell, initDigit int) Cell {
 	h := Cell(h3Init)
 	h |= Cell(cellMode) << modeOffset
-	h = setResolution(h, res)
+	h = h.setResolution(res)
 
 	h |= Cell(baseCell) << baseCellOffset
 	for r := 1; r <= res; r++ {
-		h = setIndexDigit(h, r, initDigit)
+		h = h.setIndexDigit(r, initDigit)
 	}
 
 	return h

--- a/x/h3go/sets_test.go
+++ b/x/h3go/sets_test.go
@@ -23,27 +23,27 @@ func TestSetH3IndexValue(t *testing.T) {
 	t.Parallel()
 
 	h := setH3Index(5, 12, 1)
-	if resolution(h) != 5 {
-		t.Fatalf("resolution = %d, want 5", resolution(h))
+	if h.Resolution() != 5 {
+		t.Fatalf("resolution = %d, want 5", h.Resolution())
 	}
 
-	if baseCellNumber(h) != 12 {
-		t.Fatalf("base cell = %d, want 12", baseCellNumber(h))
+	if h.BaseCellNumber() != 12 {
+		t.Fatalf("base cell = %d, want 12", h.BaseCellNumber())
 	}
 
-	if mode(h) != cellMode {
-		t.Fatalf("mode = %d, want %d", mode(h), cellMode)
+	if h.mode() != cellMode {
+		t.Fatalf("mode = %d, want %d", h.mode(), cellMode)
 	}
 
 	for r := 1; r <= 5; r++ {
-		if getIndexDigit(h, r) != 1 {
-			t.Fatalf("digit %d = %d, want 1", r, getIndexDigit(h, r))
+		if h.indexDigit(r) != 1 {
+			t.Fatalf("digit %d = %d, want 1", r, h.indexDigit(r))
 		}
 	}
 
 	for r := 6; r <= maxResolution; r++ {
-		if getIndexDigit(h, r) != invalidDigit {
-			t.Fatalf("digit %d = %d, want %d", r, getIndexDigit(h, r), invalidDigit)
+		if h.indexDigit(r) != invalidDigit {
+			t.Fatalf("digit %d = %d, want %d", r, h.indexDigit(r), invalidDigit)
 		}
 	}
 


### PR DESCRIPTION
Implement the reverse projection pipeline in pure Go: CellToLatLng (+ Cell.LatLng) and CellToBoundary (+ Cell.Boundary), with the supporting FaceIJK/coordIJK/vec2d/vec3d geometry, substrate grids, and overage adjustment. Verified against the cgo reference via paritytest and by LatLngToCell round-trips, with regression cases ported from the C tests.

Refactors applied across the package:
- Convert input-parameter helpers to methods on their natural receiver type, with one canonical receiver name per type.
- Inline pure-delegation unexported helpers into their exported methods (resolution, baseCellNumber, isPentagon); collapse isValid's guard in.
- Add isResClassIII(res) helper, replacing scattered %2 == 1 checks.
- Exclude mnd for x/h3go via path-scoped .golangci.yml rule (geometric and bit-layout constants are inherent, not magic) and drop the now-unused //nolint:mnd directives; keep gosec.