### PR TITLE
feat: add pure-Go grid traversal (k-ring/disk/ring) to x/h3go

### DIFF
--- a/x/h3go/grid.go
+++ b/x/h3go/grid.go
@@ -1,0 +1,616 @@
+/*
+ * Copyright 2026 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package h3go
+
+import (
+	"errors"
+
+	"github.com/uber/h3-go/v4/internal/h3core"
+)
+
+// directions is the ordered set of the six neighbor directions used when
+// tracing a ring counterclockwise, one side of the ring per entry.
+var directions = [6]int{
+	jAxesDigit, jkAxesDigit, kAxesDigit, ikAxesDigit, iAxesDigit, ijAxesDigit,
+}
+
+// nextRingDirection is the direction stepped to move from one ring to the next
+// larger ring before tracing it.
+const nextRingDirection = iAxesDigit
+
+// isBaseCellPolarPentagon reports whether a base cell is one of the two polar
+// pentagons, which have all-i neighbors and therefore distort differently.
+func isBaseCellPolarPentagon(baseCell int) bool {
+	return baseCell == 4 || baseCell == 117
+}
+
+// baseCellIsCwOffset reports whether testFace is one of the clockwise-offset
+// faces of a pentagon base cell.
+func baseCellIsCwOffset(baseCell, testFace int) bool {
+	offsets, ok := baseCellCWOffsetPent[baseCell]
+
+	return ok && (offsets[0] == testFace || offsets[1] == testFace)
+}
+
+// neighborRotations returns the cell adjacent to c in direction dir, applying
+// rotations counterclockwise 60° turns to dir first. It also returns the number
+// of rotations a caller should carry into the next step, which changes whenever
+// the move crosses an icosahedron face edge or pentagon distortion. It fails
+// with ErrPentagon when the move enters a pentagon's deleted k subsequence in an
+// undefined way.
+func (c Cell) neighborRotations(dir, rotations int) (Cell, int, error) {
+	current := c
+
+	if dir < centerDigit || dir >= invalidDigit {
+		return 0, 0, ErrFailed
+	}
+
+	rotations %= 6
+	for range rotations {
+		dir = rotate60ccw(dir)
+	}
+
+	newRotations := 0
+
+	oldBaseCell := current.BaseCellNumber()
+	if oldBaseCell < 0 || oldBaseCell >= numBaseCells {
+		return 0, 0, ErrCellInvalid
+	}
+
+	oldLeadingDigit := current.leadingNonZeroDigit()
+
+	res := current.Resolution() - 1
+	for {
+		if res == -1 {
+			current = current.setBaseCell(baseCellNeighbors[oldBaseCell][dir])
+			newRotations = baseCellNeighbor60CCWRots[oldBaseCell][dir]
+
+			if current.BaseCellNumber() == invalidBaseCell {
+				// Adjust for the deleted k vertex at the base cell level. This
+				// edge actually borders a different neighbor.
+				current = current.setBaseCell(baseCellNeighbors[oldBaseCell][ikAxesDigit])
+				newRotations = baseCellNeighbor60CCWRots[oldBaseCell][ikAxesDigit]
+
+				// Perform the adjustment for the k-subsequence we're skipping.
+				current = current.rotate60ccw()
+				rotations++
+			}
+
+			break
+		}
+
+		oldDigit := current.indexDigit(res + 1)
+		if oldDigit == invalidDigit {
+			return 0, 0, ErrCellInvalid
+		}
+
+		var nextDir int
+
+		if isResClassIII(res + 1) {
+			current = current.setIndexDigit(res+1, newDigitII[oldDigit][dir])
+			nextDir = newAdjustmentII[oldDigit][dir]
+		} else {
+			current = current.setIndexDigit(res+1, newDigitIII[oldDigit][dir])
+			nextDir = newAdjustmentIII[oldDigit][dir]
+		}
+
+		if nextDir == centerDigit {
+			break
+		}
+
+		dir = nextDir
+		res--
+	}
+
+	newBaseCell := current.BaseCellNumber()
+	if h3core.IsBaseCellPentagon[newBaseCell] {
+		alreadyAdjustedKSubsequence := false
+
+		// Force rotation out of the missing k-axes sub-sequence.
+		if current.leadingNonZeroDigit() == kAxesDigit {
+			if oldBaseCell != newBaseCell {
+				// We traversed into the deleted k subsequence of a different
+				// pentagon base cell. The shared edge is always that base cell's
+				// clockwise-offset face, so the rotation is clockwise.
+				if baseCellIsCwOffset(newBaseCell, baseCellHomeFijk[oldBaseCell].face) {
+					current = current.rotate60cw()
+				}
+
+				alreadyAdjustedKSubsequence = true
+			} else {
+				// We traversed into the deleted k subsequence from within the
+				// same pentagon base cell.
+				switch oldLeadingDigit {
+				case centerDigit:
+					// Undefined: the k direction is deleted from here.
+					return 0, 0, ErrPentagon
+				case jkAxesDigit:
+					current = current.rotate60ccw()
+					rotations++
+				case ikAxesDigit:
+					current = current.rotate60cw()
+					rotations += 5
+				default:
+					return 0, 0, ErrFailed
+				}
+			}
+		}
+
+		for range newRotations {
+			current = current.rotatePent60ccw()
+		}
+
+		// Account for differing orientation of the base cells.
+		if oldBaseCell != newBaseCell {
+			if isBaseCellPolarPentagon(newBaseCell) {
+				// Polar base cells behave differently because they have all i
+				// neighbors.
+				if oldBaseCell != 118 && oldBaseCell != 8 &&
+					current.leadingNonZeroDigit() != jkAxesDigit {
+					rotations++
+				}
+			} else if current.leadingNonZeroDigit() == ikAxesDigit && !alreadyAdjustedKSubsequence {
+				// Account for distortion introduced to the 5 neighbor by the
+				// deleted k subsequence.
+				rotations++
+			}
+		}
+	} else {
+		for range newRotations {
+			current = current.rotate60ccw()
+		}
+	}
+
+	rotations = (rotations + newRotations) % 6
+
+	return current, rotations, nil
+}
+
+// GridDisk returns the cells within grid distance k of the origin cell. The
+// origin is included. Output ordering is not significant. It falls back to the
+// safe traversal when the fast one meets pentagon distortion.
+func (c Cell) GridDisk(k int) ([]Cell, error) {
+	rings, err := c.GridDiskDistances(k)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []Cell
+	for _, ring := range rings {
+		out = append(out, ring...)
+	}
+
+	return out, nil
+}
+
+// GridDisk returns the cells within grid distance k of the origin cell.
+func GridDisk(origin Cell, k int) ([]Cell, error) {
+	return origin.GridDisk(k)
+}
+
+// GridDisksUnsafe returns, for each origin, the cells within grid distance k of
+// that origin. The outer slice matches the order of origins; inner ordering is
+// not significant. It fails if any disk encounters pentagon distortion.
+func GridDisksUnsafe(origins []Cell, k int) ([][]Cell, error) {
+	if len(origins) == 0 {
+		return nil, nil
+	}
+
+	out := make([][]Cell, len(origins))
+	for i, origin := range origins {
+		rings, err := origin.GridDiskDistancesUnsafe(k)
+		if err != nil {
+			return nil, err
+		}
+
+		var flat []Cell
+		for _, ring := range rings {
+			flat = append(flat, ring...)
+		}
+
+		out[i] = flat
+	}
+
+	return out, nil
+}
+
+// GridDiskDistances returns the cells within grid distance k of the origin,
+// grouped by ring: index 0 is the origin, index d holds the cells at grid
+// distance d. It optimistically tries the fast traversal, falling back to the
+// safe one on pentagon distortion.
+func (c Cell) GridDiskDistances(k int) ([][]Cell, error) {
+	rings, err := c.GridDiskDistancesUnsafe(k)
+	if err != nil {
+		return c.GridDiskDistancesSafe(k)
+	}
+
+	return rings, nil
+}
+
+// GridDiskDistances returns the cells within grid distance k of the origin,
+// grouped by ring.
+func GridDiskDistances(origin Cell, k int) ([][]Cell, error) {
+	return origin.GridDiskDistances(k)
+}
+
+// GridDiskDistancesUnsafe returns the cells within grid distance k of the
+// origin, grouped by ring, using a fast spiral traversal. It fails with
+// ErrPentagon if the spiral meets a pentagon or pentagon distortion.
+func (c Cell) GridDiskDistancesUnsafe(k int) ([][]Cell, error) {
+	if k < 0 {
+		return nil, ErrDomain
+	}
+
+	rings := make([][]Cell, k+1)
+
+	cursor := c
+	rings[0] = append(rings[0], cursor)
+
+	if cursor.IsPentagon() {
+		return nil, ErrPentagon
+	}
+
+	ring := 1
+	direction := 0
+	i := 0
+	rotations := 0
+
+	for ring <= k {
+		if direction == 0 && i == 0 {
+			next, rot, err := cursor.neighborRotations(nextRingDirection, rotations)
+			if err != nil {
+				return nil, err
+			}
+
+			cursor, rotations = next, rot
+			if cursor.IsPentagon() {
+				return nil, ErrPentagon
+			}
+		}
+
+		next, rot, err := cursor.neighborRotations(directions[direction], rotations)
+		if err != nil {
+			return nil, err
+		}
+
+		cursor, rotations = next, rot
+		rings[ring] = append(rings[ring], cursor)
+
+		i++
+		if i == ring {
+			i = 0
+			direction++
+
+			if direction == 6 {
+				direction = 0
+				ring++
+			}
+		}
+
+		if cursor.IsPentagon() {
+			return nil, ErrPentagon
+		}
+	}
+
+	return rings, nil
+}
+
+// GridDiskDistancesUnsafe returns the cells within grid distance k of the
+// origin, grouped by ring, using a fast spiral traversal.
+func GridDiskDistancesUnsafe(origin Cell, k int) ([][]Cell, error) {
+	return origin.GridDiskDistancesUnsafe(k)
+}
+
+// GridDiskDistancesSafe returns the cells within grid distance k of the origin,
+// grouped by ring, using a breadth-first traversal that tolerates pentagon
+// distortion. It is slower than the unsafe variant but always correct.
+func (c Cell) GridDiskDistancesSafe(k int) ([][]Cell, error) {
+	if k < 0 {
+		return nil, ErrDomain
+	}
+
+	rings := make([][]Cell, k+1)
+	seen := map[Cell]int{c: 0}
+	rings[0] = append(rings[0], c)
+
+	type queued struct {
+		cell Cell
+		dist int
+	}
+
+	queue := []queued{{c, 0}}
+	for len(queue) > 0 {
+		head := queue[0]
+		queue = queue[1:]
+
+		if head.dist >= k {
+			continue
+		}
+
+		for _, dir := range directions {
+			neighbor, _, err := head.cell.neighborRotations(dir, 0)
+			if err != nil {
+				if errors.Is(err, ErrPentagon) {
+					continue
+				}
+
+				return nil, err
+			}
+
+			dist := head.dist + 1
+			if prev, ok := seen[neighbor]; ok && prev <= dist {
+				continue
+			}
+
+			seen[neighbor] = dist
+			rings[dist] = append(rings[dist], neighbor)
+			queue = append(queue, queued{neighbor, dist})
+		}
+	}
+
+	return rings, nil
+}
+
+// GridDiskDistancesSafe returns the cells within grid distance k of the origin,
+// grouped by ring, using a breadth-first traversal that tolerates pentagon
+// distortion.
+func GridDiskDistancesSafe(origin Cell, k int) ([][]Cell, error) {
+	return origin.GridDiskDistancesSafe(k)
+}
+
+// GridRingUnsafe returns the hollow ring of cells at exactly grid distance k
+// from the origin, using a fast single-loop traversal. k of 0 returns just the
+// origin. It fails with ErrPentagon if the ring meets a pentagon or pentagon
+// distortion.
+func (c Cell) GridRingUnsafe(k int) ([]Cell, error) {
+	if k < 0 {
+		return nil, ErrDomain
+	}
+
+	if k == 0 {
+		return []Cell{c}, nil
+	}
+
+	cursor := c
+	rotations := 0
+
+	if cursor.IsPentagon() {
+		return nil, ErrPentagon
+	}
+
+	for range k {
+		next, rot, err := cursor.neighborRotations(nextRingDirection, rotations)
+		if err != nil {
+			return nil, err
+		}
+
+		cursor, rotations = next, rot
+		if cursor.IsPentagon() {
+			return nil, ErrPentagon
+		}
+	}
+
+	lastIndex := cursor
+	out := []Cell{cursor}
+
+	for direction := 0; direction < 6; direction++ {
+		for pos := 0; pos < k; pos++ {
+			next, rot, err := cursor.neighborRotations(directions[direction], rotations)
+			if err != nil {
+				return nil, err
+			}
+
+			cursor, rotations = next, rot
+
+			// Skip the very last index; it equals the first one already added.
+			// We still traverse to it for the pentagon-distortion check below.
+			if pos != k-1 || direction != 5 {
+				out = append(out, cursor)
+
+				if cursor.IsPentagon() {
+					return nil, ErrPentagon
+				}
+			}
+		}
+	}
+
+	// If the loop didn't return to its start, pentagon distortion occurred.
+	if lastIndex != cursor {
+		return nil, ErrPentagon
+	}
+
+	return out, nil
+}
+
+// GridRingUnsafe returns the hollow ring of cells at exactly grid distance k
+// from the origin, using a fast single-loop traversal.
+func GridRingUnsafe(origin Cell, k int) ([]Cell, error) {
+	return origin.GridRingUnsafe(k)
+}
+
+// GridRing returns the hollow ring of cells at exactly grid distance k from the
+// origin. It tries the fast traversal first and falls back to the safe disk
+// traversal when pentagon distortion is encountered.
+func (c Cell) GridRing(k int) ([]Cell, error) {
+	out, err := c.GridRingUnsafe(k)
+	if err == nil {
+		return out, nil
+	}
+
+	if k < 0 {
+		return nil, ErrDomain
+	}
+
+	rings, err := c.GridDiskDistancesSafe(k)
+	if err != nil {
+		return nil, err
+	}
+
+	return rings[k], nil
+}
+
+// GridRing returns the hollow ring of cells at exactly grid distance k from the
+// origin.
+func GridRing(origin Cell, k int) ([]Cell, error) {
+	return origin.GridRing(k)
+}
+
+// IsNeighbor reports whether c and other are adjacent cells at the same
+// resolution.
+func (c Cell) IsNeighbor(other Cell) (bool, error) {
+	if c.mode() != cellMode || other.mode() != cellMode {
+		return false, ErrCellInvalid
+	}
+
+	// A cell is never its own neighbor.
+	if c == other {
+		return false, nil
+	}
+
+	if c.Resolution() != other.Resolution() {
+		return false, ErrResolutionMismatch
+	}
+
+	// Cells that share a parent are very likely neighbors; a digit lookup is a
+	// cheap way to decide many cases before the general traversal.
+	parentRes := c.Resolution() - 1
+	if parentRes > 0 {
+		originParent, originErr := c.Parent(parentRes)
+		destParent, destErr := other.Parent(parentRes)
+
+		if originErr == nil && destErr == nil && originParent == destParent {
+			originResDigit := c.indexDigit(parentRes + 1)
+			destResDigit := other.indexDigit(parentRes + 1)
+
+			if originResDigit == centerDigit || destResDigit == centerDigit {
+				return true, nil
+			}
+
+			if originResDigit >= invalidDigit {
+				return false, ErrCellInvalid
+			}
+
+			if (originResDigit == kAxesDigit || destResDigit == kAxesDigit) &&
+				originParent.IsPentagon() {
+				// Real neighbors across a pentagon's deleted subsequence fail
+				// this optimized check but are accepted by the disk check below.
+				return false, ErrCellInvalid
+			}
+
+			// neighborDigits maps an indexing digit to the two adjacent digits
+			// (clockwise, counterclockwise) of the cells that share this parent
+			// and neighbor the origin.
+			neighborDigits := [7][2]int{
+				{centerDigit, centerDigit},
+				{jkAxesDigit, ikAxesDigit},
+				{ijAxesDigit, jkAxesDigit},
+				{jAxesDigit, kAxesDigit},
+				{ikAxesDigit, ijAxesDigit},
+				{kAxesDigit, iAxesDigit},
+				{iAxesDigit, jAxesDigit},
+			}
+
+			//nolint:gosec // originResDigit is in [1,6] here (center and out-of-range digits are handled above), so this fixed-size lookup stays in bounds.
+			adjacent := neighborDigits[originResDigit]
+			if adjacent[0] == destResDigit || adjacent[1] == destResDigit {
+				return true, nil
+			}
+		}
+	}
+
+	// Otherwise determine the relationship the hard way.
+	ring, err := c.GridDisk(1)
+	if err != nil {
+		return false, err
+	}
+
+	for _, cell := range ring {
+		if cell == other {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// newDigitII maps current digit and direction to the new digit on a Class II grid.
+var newDigitII = [7][7]int{
+	{centerDigit, kAxesDigit, jAxesDigit, jkAxesDigit, iAxesDigit,
+		ikAxesDigit, ijAxesDigit},
+	{kAxesDigit, iAxesDigit, jkAxesDigit, ijAxesDigit, ikAxesDigit,
+		jAxesDigit, centerDigit},
+	{jAxesDigit, jkAxesDigit, kAxesDigit, iAxesDigit, ijAxesDigit,
+		centerDigit, ikAxesDigit},
+	{jkAxesDigit, ijAxesDigit, iAxesDigit, ikAxesDigit, centerDigit,
+		kAxesDigit, jAxesDigit},
+	{iAxesDigit, ikAxesDigit, ijAxesDigit, centerDigit, jAxesDigit,
+		jkAxesDigit, kAxesDigit},
+	{ikAxesDigit, jAxesDigit, centerDigit, kAxesDigit, jkAxesDigit,
+		ijAxesDigit, iAxesDigit},
+	{ijAxesDigit, centerDigit, ikAxesDigit, jAxesDigit, kAxesDigit,
+		iAxesDigit, jkAxesDigit}}
+
+// newAdjustmentII maps current digit and direction to the coarser ap7 move on a Class II grid.
+var newAdjustmentII = [7][7]int{
+	{centerDigit, centerDigit, centerDigit, centerDigit, centerDigit,
+		centerDigit, centerDigit},
+	{centerDigit, kAxesDigit, centerDigit, kAxesDigit, centerDigit,
+		ikAxesDigit, centerDigit},
+	{centerDigit, centerDigit, jAxesDigit, jkAxesDigit, centerDigit,
+		centerDigit, jAxesDigit},
+	{centerDigit, kAxesDigit, jkAxesDigit, jkAxesDigit, centerDigit,
+		centerDigit, centerDigit},
+	{centerDigit, centerDigit, centerDigit, centerDigit, iAxesDigit,
+		iAxesDigit, ijAxesDigit},
+	{centerDigit, ikAxesDigit, centerDigit, centerDigit, iAxesDigit,
+		ikAxesDigit, centerDigit},
+	{centerDigit, centerDigit, jAxesDigit, centerDigit, ijAxesDigit,
+		centerDigit, ijAxesDigit}}
+
+// newDigitIII maps current digit and direction to the new digit on a Class III grid.
+var newDigitIII = [7][7]int{
+	{centerDigit, kAxesDigit, jAxesDigit, jkAxesDigit, iAxesDigit,
+		ikAxesDigit, ijAxesDigit},
+	{kAxesDigit, jAxesDigit, jkAxesDigit, iAxesDigit, ikAxesDigit,
+		ijAxesDigit, centerDigit},
+	{jAxesDigit, jkAxesDigit, iAxesDigit, ikAxesDigit, ijAxesDigit,
+		centerDigit, kAxesDigit},
+	{jkAxesDigit, iAxesDigit, ikAxesDigit, ijAxesDigit, centerDigit,
+		kAxesDigit, jAxesDigit},
+	{iAxesDigit, ikAxesDigit, ijAxesDigit, centerDigit, kAxesDigit,
+		jAxesDigit, jkAxesDigit},
+	{ikAxesDigit, ijAxesDigit, centerDigit, kAxesDigit, jAxesDigit,
+		jkAxesDigit, iAxesDigit},
+	{ijAxesDigit, centerDigit, kAxesDigit, jAxesDigit, jkAxesDigit,
+		iAxesDigit, ikAxesDigit}}
+
+// newAdjustmentIII maps current digit and direction to the coarser ap7 move on a Class III grid.
+var newAdjustmentIII = [7][7]int{
+	{centerDigit, centerDigit, centerDigit, centerDigit, centerDigit,
+		centerDigit, centerDigit},
+	{centerDigit, kAxesDigit, centerDigit, jkAxesDigit, centerDigit,
+		kAxesDigit, centerDigit},
+	{centerDigit, centerDigit, jAxesDigit, jAxesDigit, centerDigit,
+		centerDigit, ijAxesDigit},
+	{centerDigit, jkAxesDigit, jAxesDigit, jkAxesDigit, centerDigit,
+		centerDigit, centerDigit},
+	{centerDigit, centerDigit, centerDigit, centerDigit, iAxesDigit,
+		ikAxesDigit, iAxesDigit},
+	{centerDigit, kAxesDigit, centerDigit, centerDigit, ikAxesDigit,
+		ikAxesDigit, centerDigit},
+	{centerDigit, centerDigit, ijAxesDigit, centerDigit, iAxesDigit,
+		centerDigit, ijAxesDigit}}

--- a/x/h3go/grid_test.go
+++ b/x/h3go/grid_test.go
@@ -1,0 +1,570 @@
+/*
+ * Copyright 2026 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package h3go
+
+import (
+	"errors"
+	"testing"
+)
+
+// gridCorpus builds a deterministic set of cells exercising hexagons, pentagons,
+// pentagon children (which reach the distortion paths), and cells around the
+// poles and antimeridian. It is shared read-only across the grid tests.
+func gridCorpus(t *testing.T) []Cell {
+	t.Helper()
+
+	res0, err := Res0Cells()
+	if err != nil {
+		t.Fatalf("Res0Cells: %v", err)
+	}
+
+	cells := append([]Cell{}, res0...)
+
+	points := []LatLng{
+		{Lat: 0, Lng: 0},
+		{Lat: 37.7749, Lng: -122.4194},
+		{Lat: 67.1509, Lng: -168.3908},
+		{Lat: -45, Lng: 170},
+		{Lat: 89.9, Lng: 0},
+	}
+
+	for res := 0; res <= 6; res++ {
+		for _, point := range points {
+			if cell, err := LatLngToCell(point, res); err == nil {
+				cells = append(cells, cell)
+			}
+		}
+
+		pents, err := Pentagons(res)
+		if err != nil {
+			t.Fatalf("Pentagons(%d): %v", res, err)
+		}
+
+		cells = append(cells, pents...)
+
+		// Children of a pentagon reach the pentagon-distortion branches when
+		// their disks and rings are traced; two generations down places cells
+		// right against the deleted edge, where the fast traversals fail.
+		for _, pent := range pents {
+			children, err := pent.Children(res + 2)
+			if err != nil {
+				t.Fatalf("Children(%015x): %v", uint64(pent), err)
+			}
+
+			cells = append(cells, children...)
+		}
+	}
+
+	return cells
+}
+
+// cellSet returns the cells of in as a set for membership tests, dropping zeros.
+func cellSet(in []Cell) map[Cell]bool {
+	set := make(map[Cell]bool, len(in))
+	for _, cell := range in {
+		if cell != 0 {
+			set[cell] = true
+		}
+	}
+
+	return set
+}
+
+// TestGridDiskDistancesConsistency checks the internal invariants of the disk
+// family over the corpus: the origin sits alone in ring 0, GridDisk equals the
+// flattened distances, and the safe and (when it succeeds) unsafe traversals
+// agree as sets.
+func TestGridDiskDistancesConsistency(t *testing.T) {
+	t.Parallel()
+
+	for _, origin := range gridCorpus(t) {
+		for _, k := range []int{0, 1, 2, 3} {
+			rings, err := origin.GridDiskDistances(k)
+			if err != nil {
+				t.Fatalf("GridDiskDistances(%015x, %d): %v", uint64(origin), k, err)
+			}
+
+			if len(rings) != k+1 {
+				t.Fatalf("GridDiskDistances(%015x, %d): %d rings, want %d", uint64(origin), k, len(rings), k+1)
+			}
+
+			if len(rings[0]) != 1 || rings[0][0] != origin {
+				t.Fatalf("GridDiskDistances(%015x, %d): ring 0 = %v, want [origin]", uint64(origin), k, rings[0])
+			}
+
+			disk, err := origin.GridDisk(k)
+			if err != nil {
+				t.Fatalf("GridDisk(%015x, %d): %v", uint64(origin), k, err)
+			}
+
+			var flat int
+			for _, ring := range rings {
+				flat += len(ring)
+			}
+
+			if len(disk) != flat {
+				t.Fatalf("GridDisk(%015x, %d): %d cells, flattened distances had %d", uint64(origin), k, len(disk), flat)
+			}
+
+			safe, err := origin.GridDiskDistancesSafe(k)
+			if err != nil {
+				t.Fatalf("GridDiskDistancesSafe(%015x, %d): %v", uint64(origin), k, err)
+			}
+
+			unsafe, unsafeErr := origin.GridDiskDistancesUnsafe(k)
+			if unsafeErr == nil {
+				for ring := range safe {
+					assertSameSet(t, unsafe[ring], safe[ring], "unsafe vs safe ring")
+				}
+			}
+		}
+	}
+}
+
+// TestGridRingMatchesDiskRing checks that GridRing yields exactly the cells at
+// distance k from the disk's ring k, over the corpus, and that the free function
+// delegates to the method.
+func TestGridRingMatchesDiskRing(t *testing.T) {
+	t.Parallel()
+
+	for _, origin := range gridCorpus(t) {
+		for _, k := range []int{0, 1, 2, 3} {
+			rings, err := origin.GridDiskDistances(k)
+			if err != nil {
+				t.Fatalf("GridDiskDistances(%015x, %d): %v", uint64(origin), k, err)
+			}
+
+			ring, err := GridRing(origin, k)
+			if err != nil {
+				t.Fatalf("GridRing(%015x, %d): %v", uint64(origin), k, err)
+			}
+
+			assertSameSet(t, ring, rings[k], "GridRing vs disk ring")
+		}
+	}
+}
+
+// TestGridRingUnsafeMatchesGridRing checks that when GridRingUnsafe succeeds its
+// result matches GridRing as a set, exercising the fast single-loop traversal.
+func TestGridRingUnsafeMatchesGridRing(t *testing.T) {
+	t.Parallel()
+
+	for _, origin := range gridCorpus(t) {
+		for _, k := range []int{1, 2, 3, 4, 5} {
+			unsafe, err := GridRingUnsafe(origin, k)
+			if err != nil {
+				continue
+			}
+
+			ring, err := origin.GridRing(k)
+			if err != nil {
+				t.Fatalf("GridRing(%015x, %d): %v", uint64(origin), k, err)
+			}
+
+			assertSameSet(t, unsafe, ring, "GridRingUnsafe vs GridRing")
+		}
+	}
+}
+
+// TestGridDisksUnsafe covers the batch traversal: the empty-input short circuit
+// and equivalence with per-origin GridDiskDistancesUnsafe over a hexagon-only
+// subset (the batch fails fast on any pentagon).
+func TestGridDisksUnsafe(t *testing.T) {
+	t.Parallel()
+
+	if out, err := GridDisksUnsafe(nil, 2); out != nil || err != nil {
+		t.Fatalf("GridDisksUnsafe(nil): got %v, %v, want nil, nil", out, err)
+	}
+
+	origins := []Cell{
+		CellFromString("8928308280fffff"),
+		CellFromString("85283473fffffff"),
+	}
+
+	const k = 2
+
+	batch, err := GridDisksUnsafe(origins, k)
+	if err != nil {
+		t.Fatalf("GridDisksUnsafe: %v", err)
+	}
+
+	for i, origin := range origins {
+		rings, err := origin.GridDiskDistancesUnsafe(k)
+		if err != nil {
+			t.Fatalf("GridDiskDistancesUnsafe(%015x): %v", uint64(origin), err)
+		}
+
+		var flat []Cell
+		for _, ring := range rings {
+			flat = append(flat, ring...)
+		}
+
+		assertSameSet(t, batch[i], flat, "batch vs per-origin disk")
+	}
+}
+
+// TestGridDisksUnsafePentagonFails checks that the batch traversal propagates the
+// pentagon failure from any single origin.
+func TestGridDisksUnsafePentagonFails(t *testing.T) {
+	t.Parallel()
+
+	pents, err := Pentagons(5)
+	if err != nil {
+		t.Fatalf("Pentagons(5): %v", err)
+	}
+
+	origins := append([]Cell{CellFromString("8928308280fffff")}, pents[0])
+	if _, err := GridDisksUnsafe(origins, 1); !errors.Is(err, ErrPentagon) {
+		t.Fatalf("GridDisksUnsafe with pentagon: got %v, want ErrPentagon", err)
+	}
+}
+
+// TestGridDomainErrors checks that every variant rejects a negative k with
+// ErrDomain.
+func TestGridDomainErrors(t *testing.T) {
+	t.Parallel()
+
+	origin := CellFromString("8928308280fffff")
+
+	if _, err := origin.GridDiskDistancesUnsafe(-1); !errors.Is(err, ErrDomain) {
+		t.Fatalf("GridDiskDistancesUnsafe(-1): got %v, want ErrDomain", err)
+	}
+
+	if _, err := origin.GridDiskDistancesSafe(-1); !errors.Is(err, ErrDomain) {
+		t.Fatalf("GridDiskDistancesSafe(-1): got %v, want ErrDomain", err)
+	}
+
+	if _, err := origin.GridDisk(-1); !errors.Is(err, ErrDomain) {
+		t.Fatalf("GridDisk(-1): got %v, want ErrDomain", err)
+	}
+
+	if _, err := origin.GridRingUnsafe(-1); !errors.Is(err, ErrDomain) {
+		t.Fatalf("GridRingUnsafe(-1): got %v, want ErrDomain", err)
+	}
+
+	if _, err := origin.GridRing(-1); !errors.Is(err, ErrDomain) {
+		t.Fatalf("GridRing(-1): got %v, want ErrDomain", err)
+	}
+}
+
+// TestGridPentagonFallback checks that the unsafe variants report ErrPentagon on
+// a pentagon origin while the safe/auto variants succeed via fallback.
+func TestGridPentagonFallback(t *testing.T) {
+	t.Parallel()
+
+	pents, err := Pentagons(3)
+	if err != nil {
+		t.Fatalf("Pentagons(3): %v", err)
+	}
+
+	pentagon := pents[0]
+
+	if _, err := pentagon.GridDiskDistancesUnsafe(2); !errors.Is(err, ErrPentagon) {
+		t.Fatalf("GridDiskDistancesUnsafe(pentagon): got %v, want ErrPentagon", err)
+	}
+
+	if _, err := pentagon.GridRingUnsafe(2); !errors.Is(err, ErrPentagon) {
+		t.Fatalf("GridRingUnsafe(pentagon): got %v, want ErrPentagon", err)
+	}
+
+	if _, err := pentagon.GridDisk(2); err != nil {
+		t.Fatalf("GridDisk(pentagon): %v", err)
+	}
+
+	if _, err := pentagon.GridRing(2); err != nil {
+		t.Fatalf("GridRing(pentagon): %v", err)
+	}
+}
+
+// TestNeighborRotationsErrors covers the error paths of neighborRotations that a
+// validly constructed cell cannot reach through the public traversal API.
+func TestNeighborRotationsErrors(t *testing.T) {
+	t.Parallel()
+
+	origin := CellFromString("8928308280fffff")
+
+	if _, _, err := origin.neighborRotations(invalidDigit, 0); !errors.Is(err, ErrFailed) {
+		t.Fatalf("neighborRotations(invalidDigit): got %v, want ErrFailed", err)
+	}
+
+	if _, _, err := origin.neighborRotations(-1, 0); !errors.Is(err, ErrFailed) {
+		t.Fatalf("neighborRotations(-1): got %v, want ErrFailed", err)
+	}
+
+	badBaseCell := Cell(h3Init) | Cell(cellMode)<<modeOffset | Cell(numBaseCells)<<baseCellOffset
+	if _, _, err := badBaseCell.neighborRotations(kAxesDigit, 0); !errors.Is(err, ErrCellInvalid) {
+		t.Fatalf("neighborRotations(bad base cell): got %v, want ErrCellInvalid", err)
+	}
+
+	badDigit := origin.setIndexDigit(origin.Resolution(), invalidDigit)
+	if _, _, err := badDigit.neighborRotations(kAxesDigit, 0); !errors.Is(err, ErrCellInvalid) {
+		t.Fatalf("neighborRotations(invalid digit): got %v, want ErrCellInvalid", err)
+	}
+
+	// A malformed pentagon index can land in the deleted k subsequence with a
+	// leading digit the pentagon adjustment does not define, which is rejected.
+	if _, _, err := Cell(0x810840000000000).neighborRotations(centerDigit, 0); !errors.Is(err, ErrFailed) {
+		t.Fatalf("neighborRotations(undefined pentagon move): got %v, want ErrFailed", err)
+	}
+}
+
+// TestGridDefensiveErrors covers the error-propagation paths in the traversals
+// that a validly constructed cell cannot reach, using malformed indexes whose
+// invalid digits make the internal neighbor step fail partway through.
+func TestGridDefensiveErrors(t *testing.T) {
+	t.Parallel()
+
+	base := CellFromString("8928308280fffff")
+
+	// firstStep fails on the move to the next ring; secondStep passes that move
+	// but fails while tracing the ring. Together they exercise both neighbor-step
+	// error returns in the fast disk and ring traversals.
+	firstStep := base.setIndexDigit(9, invalidDigit)
+	secondStep := base.setIndexDigit(8, invalidDigit)
+
+	for _, malformed := range []Cell{firstStep, secondStep} {
+		if _, err := malformed.GridDiskDistancesUnsafe(1); err == nil {
+			t.Fatalf("GridDiskDistancesUnsafe(%015x): got nil error, want failure", uint64(malformed))
+		}
+
+		if _, err := malformed.GridRingUnsafe(1); err == nil {
+			t.Fatalf("GridRingUnsafe(%015x): got nil error, want failure", uint64(malformed))
+		}
+	}
+
+	// The safe traversal surfaces the same non-pentagon failure, and the disk
+	// and ring fallbacks propagate it.
+	if _, err := firstStep.GridDiskDistancesSafe(1); err == nil {
+		t.Fatal("GridDiskDistancesSafe(malformed): got nil error, want failure")
+	}
+
+	if _, err := firstStep.GridDisk(1); err == nil {
+		t.Fatal("GridDisk(malformed): got nil error, want failure")
+	}
+
+	if _, err := firstStep.GridRing(1); err == nil {
+		t.Fatal("GridRing(malformed): got nil error, want failure")
+	}
+}
+
+// TestNeighborRotationsResetByRotations checks that the rotations argument is
+// reduced modulo 6 and applied to the direction, so a six-fold rotation is a
+// no-op relative to none.
+func TestNeighborRotationsResetByRotations(t *testing.T) {
+	t.Parallel()
+
+	origin := CellFromString("8928308280fffff")
+
+	base, baseRot, err := origin.neighborRotations(kAxesDigit, 0)
+	if err != nil {
+		t.Fatalf("neighborRotations(0 rotations): %v", err)
+	}
+
+	six, sixRot, err := origin.neighborRotations(kAxesDigit, 6)
+	if err != nil {
+		t.Fatalf("neighborRotations(6 rotations): %v", err)
+	}
+
+	if base != six || baseRot != sixRot {
+		t.Fatalf("rotations not modulo 6: (%015x,%d) vs (%015x,%d)", uint64(base), baseRot, uint64(six), sixRot)
+	}
+}
+
+// TestIsNeighbor covers the neighbor relation: self is never a neighbor, true
+// neighbors from the ring, non-neighbors, resolution mismatch, and non-cell mode.
+func TestIsNeighbor(t *testing.T) {
+	t.Parallel()
+
+	origin := CellFromString("8928308280fffff")
+
+	if got, err := origin.IsNeighbor(origin); err != nil || got {
+		t.Fatalf("IsNeighbor(self): got %v, %v, want false, nil", got, err)
+	}
+
+	ring, err := origin.GridRing(1)
+	if err != nil {
+		t.Fatalf("GridRing(1): %v", err)
+	}
+
+	for _, neighbor := range ring {
+		if got, err := origin.IsNeighbor(neighbor); err != nil || !got {
+			t.Fatalf("IsNeighbor(%015x, %015x): got %v, %v, want true, nil", uint64(origin), uint64(neighbor), got, err)
+		}
+	}
+
+	far, err := LatLngToCell(LatLng{Lat: -33.8688, Lng: 151.2093}, 9)
+	if err != nil {
+		t.Fatalf("LatLngToCell(far): %v", err)
+	}
+
+	if got, err := origin.IsNeighbor(far); err != nil || got {
+		t.Fatalf("IsNeighbor(far): got %v, %v, want false, nil", got, err)
+	}
+
+	parent, err := origin.ImmediateParent()
+	if err != nil {
+		t.Fatalf("ImmediateParent: %v", err)
+	}
+
+	if _, err := origin.IsNeighbor(parent); !errors.Is(err, ErrResolutionMismatch) {
+		t.Fatalf("IsNeighbor(parent): got %v, want ErrResolutionMismatch", err)
+	}
+
+	notACell := origin &^ (Cell(modeMask) << modeOffset)
+	if _, err := notACell.IsNeighbor(origin); !errors.Is(err, ErrCellInvalid) {
+		t.Fatalf("IsNeighbor(non-cell): got %v, want ErrCellInvalid", err)
+	}
+
+	if _, err := origin.IsNeighbor(notACell); !errors.Is(err, ErrCellInvalid) {
+		t.Fatalf("IsNeighbor(other non-cell): got %v, want ErrCellInvalid", err)
+	}
+}
+
+// TestIsNeighborPentagon exercises the optimized same-parent branch around a
+// pentagon, where a k-axis digit under a pentagon parent is rejected as invalid.
+func TestIsNeighborPentagon(t *testing.T) {
+	t.Parallel()
+
+	pents, err := Pentagons(5)
+	if err != nil {
+		t.Fatalf("Pentagons(5): %v", err)
+	}
+
+	pentagon := pents[0]
+
+	children, err := pentagon.Children(6)
+	if err != nil {
+		t.Fatalf("Children(6): %v", err)
+	}
+
+	// Every child shares the pentagon parent; comparing children exercises the
+	// same-parent optimization including the deleted-k rejection.
+	for _, a := range children {
+		for _, b := range children {
+			if _, err := a.IsNeighbor(b); err != nil && !errors.Is(err, ErrCellInvalid) {
+				t.Fatalf("IsNeighbor(%015x, %015x): unexpected error %v", uint64(a), uint64(b), err)
+			}
+		}
+	}
+}
+
+// TestIsNeighborDefensive covers the invalid-input branches of IsNeighbor that a
+// validly constructed pair cannot reach: an out-of-range indexing digit under a
+// shared parent, a k-axis digit under a shared pentagon parent, and a malformed
+// origin that fails the general disk fallback.
+func TestIsNeighborDefensive(t *testing.T) {
+	t.Parallel()
+
+	base := CellFromString("8928308280fffff")
+
+	// Same res-8 parent, but the origin's finest digit is the unused sentinel.
+	invalidChild := base.setIndexDigit(9, invalidDigit)
+	sibling := base.setIndexDigit(9, jAxesDigit)
+
+	if _, err := invalidChild.IsNeighbor(sibling); !errors.Is(err, ErrCellInvalid) {
+		t.Fatalf("IsNeighbor(invalid digit child): got %v, want ErrCellInvalid", err)
+	}
+
+	// Same pentagon parent, with a k-axis digit that the deleted subsequence
+	// makes invalid.
+	pents, err := Pentagons(8)
+	if err != nil {
+		t.Fatalf("Pentagons(8): %v", err)
+	}
+
+	pentParent := pents[0]
+	kChild := pentParent.setResolution(9).setIndexDigit(9, kAxesDigit)
+	otherChild := pentParent.setResolution(9).setIndexDigit(9, jAxesDigit)
+
+	if _, err := kChild.IsNeighbor(otherChild); !errors.Is(err, ErrCellInvalid) {
+		t.Fatalf("IsNeighbor(k-axis pentagon child): got %v, want ErrCellInvalid", err)
+	}
+
+	// A malformed origin with a different parent than the target skips the
+	// optimization and fails in the general disk fallback.
+	malformed := base.setIndexDigit(9, invalidDigit)
+
+	far, err := LatLngToCell(LatLng{Lat: -33.8688, Lng: 151.2093}, 9)
+	if err != nil {
+		t.Fatalf("LatLngToCell(far): %v", err)
+	}
+
+	if _, err := malformed.IsNeighbor(far); err == nil {
+		t.Fatal("IsNeighbor(malformed, far): got nil error, want failure")
+	}
+}
+
+// TestGridFreeFunctions checks that the package-level free functions delegate to
+// the Cell methods and return matching results.
+func TestGridFreeFunctions(t *testing.T) {
+	t.Parallel()
+
+	origin := CellFromString("8928308280fffff")
+
+	const k = 2
+
+	disk, err := GridDisk(origin, k)
+	if err != nil {
+		t.Fatalf("GridDisk: %v", err)
+	}
+
+	method, err := origin.GridDisk(k)
+	if err != nil {
+		t.Fatalf("Cell.GridDisk: %v", err)
+	}
+
+	assertSameSet(t, disk, method, "GridDisk free vs method")
+
+	auto, err := GridDiskDistances(origin, k)
+	if err != nil {
+		t.Fatalf("GridDiskDistances: %v", err)
+	}
+
+	unsafe, err := GridDiskDistancesUnsafe(origin, k)
+	if err != nil {
+		t.Fatalf("GridDiskDistancesUnsafe: %v", err)
+	}
+
+	safe, err := GridDiskDistancesSafe(origin, k)
+	if err != nil {
+		t.Fatalf("GridDiskDistancesSafe: %v", err)
+	}
+
+	for ring := range auto {
+		assertSameSet(t, auto[ring], unsafe[ring], "auto vs unsafe ring")
+		assertSameSet(t, auto[ring], safe[ring], "auto vs safe ring")
+	}
+}
+
+// assertSameSet fails if two cell slices differ as sets, ignoring order and
+// zero padding.
+func assertSameSet(t *testing.T, got, want []Cell, msg string) {
+	t.Helper()
+
+	gotSet := cellSet(got)
+	wantSet := cellSet(want)
+
+	if len(gotSet) != len(wantSet) {
+		t.Fatalf("%s: set sizes differ got=%d want=%d", msg, len(gotSet), len(wantSet))
+	}
+
+	for cell := range wantSet {
+		if !gotSet[cell] {
+			t.Fatalf("%s: missing %015x", msg, uint64(cell))
+		}
+	}
+}

--- a/x/h3go/h3go.go
+++ b/x/h3go/h3go.go
@@ -47,6 +47,7 @@ var (
 	ErrResolutionMismatch = errors.New("H3Index cell arguments had incompatible resolutions")
 	ErrCellInvalid        = errors.New("H3Index cell argument was not valid")
 	ErrDuplicateInput     = errors.New("duplicate input was encountered in the arguments")
+	ErrPentagon           = errors.New("pentagon distortion was encountered")
 )
 
 // Internal types for the pure Go projection pipeline.
@@ -630,4 +631,264 @@ var baseCellHomeFijk = [numBaseCells]faceIJK{
 	{18, coordIJK{0, 0, 0}}, // base cell 119
 	{19, coordIJK{1, 0, 1}}, // base cell 120
 	{18, coordIJK{1, 0, 0}}, // base cell 121
+}
+
+// invalidBaseCell is the sentinel in baseCellNeighbors marking the missing
+// neighbor across a pentagon's deleted k-axis edge.
+const invalidBaseCell = 127
+
+// baseCellNeighbors[baseCell][dir] is the base cell reached by stepping from
+// baseCell in direction dir, or invalidBaseCell across a pentagon's deleted edge.
+var baseCellNeighbors = [numBaseCells][7]int{
+	{0, 1, 5, 2, 4, 3, 8},                       // base cell 0
+	{1, 7, 6, 9, 0, 3, 2},                       // base cell 1
+	{2, 6, 10, 11, 0, 1, 5},                     // base cell 2
+	{3, 13, 1, 7, 4, 12, 0},                     // base cell 3
+	{4, invalidBaseCell, 15, 8, 3, 0, 12},       // base cell 4 (pentagon)
+	{5, 2, 18, 10, 8, 0, 16},                    // base cell 5
+	{6, 14, 11, 17, 1, 9, 2},                    // base cell 6
+	{7, 21, 9, 19, 3, 13, 1},                    // base cell 7
+	{8, 5, 22, 16, 4, 0, 15},                    // base cell 8
+	{9, 19, 14, 20, 1, 7, 6},                    // base cell 9
+	{10, 11, 24, 23, 5, 2, 18},                  // base cell 10
+	{11, 17, 23, 25, 2, 6, 10},                  // base cell 11
+	{12, 28, 13, 26, 4, 15, 3},                  // base cell 12
+	{13, 26, 21, 29, 3, 12, 7},                  // base cell 13
+	{14, invalidBaseCell, 17, 27, 9, 20, 6},     // base cell 14 (pentagon)
+	{15, 22, 28, 31, 4, 8, 12},                  // base cell 15
+	{16, 18, 33, 30, 8, 5, 22},                  // base cell 16
+	{17, 11, 14, 6, 35, 25, 27},                 // base cell 17
+	{18, 24, 30, 32, 5, 10, 16},                 // base cell 18
+	{19, 34, 20, 36, 7, 21, 9},                  // base cell 19
+	{20, 14, 19, 9, 40, 27, 36},                 // base cell 20
+	{21, 38, 19, 34, 13, 29, 7},                 // base cell 21
+	{22, 16, 41, 33, 15, 8, 31},                 // base cell 22
+	{23, 24, 11, 10, 39, 37, 25},                // base cell 23
+	{24, invalidBaseCell, 32, 37, 10, 23, 18},   // base cell 24 (pentagon)
+	{25, 23, 17, 11, 45, 39, 35},                // base cell 25
+	{26, 42, 29, 43, 12, 28, 13},                // base cell 26
+	{27, 40, 35, 46, 14, 20, 17},                // base cell 27
+	{28, 31, 42, 44, 12, 15, 26},                // base cell 28
+	{29, 43, 38, 47, 13, 26, 21},                // base cell 29
+	{30, 32, 48, 50, 16, 18, 33},                // base cell 30
+	{31, 41, 44, 53, 15, 22, 28},                // base cell 31
+	{32, 30, 24, 18, 52, 50, 37},                // base cell 32
+	{33, 30, 49, 48, 22, 16, 41},                // base cell 33
+	{34, 19, 38, 21, 54, 36, 51},                // base cell 34
+	{35, 46, 45, 56, 17, 27, 25},                // base cell 35
+	{36, 20, 34, 19, 55, 40, 54},                // base cell 36
+	{37, 39, 52, 57, 24, 23, 32},                // base cell 37
+	{38, invalidBaseCell, 34, 51, 29, 47, 21},   // base cell 38 (pentagon)
+	{39, 37, 25, 23, 59, 57, 45},                // base cell 39
+	{40, 27, 36, 20, 60, 46, 55},                // base cell 40
+	{41, 49, 53, 61, 22, 33, 31},                // base cell 41
+	{42, 58, 43, 62, 28, 44, 26},                // base cell 42
+	{43, 62, 47, 64, 26, 42, 29},                // base cell 43
+	{44, 53, 58, 65, 28, 31, 42},                // base cell 44
+	{45, 39, 35, 25, 63, 59, 56},                // base cell 45
+	{46, 60, 56, 68, 27, 40, 35},                // base cell 46
+	{47, 38, 43, 29, 69, 51, 64},                // base cell 47
+	{48, 49, 30, 33, 67, 66, 50},                // base cell 48
+	{49, invalidBaseCell, 61, 66, 33, 48, 41},   // base cell 49 (pentagon)
+	{50, 48, 32, 30, 70, 67, 52},                // base cell 50
+	{51, 69, 54, 71, 38, 47, 34},                // base cell 51
+	{52, 57, 70, 74, 32, 37, 50},                // base cell 52
+	{53, 61, 65, 75, 31, 41, 44},                // base cell 53
+	{54, 71, 55, 73, 34, 51, 36},                // base cell 54
+	{55, 40, 54, 36, 72, 60, 73},                // base cell 55
+	{56, 68, 63, 77, 35, 46, 45},                // base cell 56
+	{57, 59, 74, 78, 37, 39, 52},                // base cell 57
+	{58, invalidBaseCell, 62, 76, 44, 65, 42},   // base cell 58 (pentagon)
+	{59, 63, 78, 79, 39, 45, 57},                // base cell 59
+	{60, 72, 68, 80, 40, 55, 46},                // base cell 60
+	{61, 53, 49, 41, 81, 75, 66},                // base cell 61
+	{62, 43, 58, 42, 82, 64, 76},                // base cell 62
+	{63, invalidBaseCell, 56, 45, 79, 59, 77},   // base cell 63 (pentagon)
+	{64, 47, 62, 43, 84, 69, 82},                // base cell 64
+	{65, 58, 53, 44, 86, 76, 75},                // base cell 65
+	{66, 67, 81, 85, 49, 48, 61},                // base cell 66
+	{67, 66, 50, 48, 87, 85, 70},                // base cell 67
+	{68, 56, 60, 46, 90, 77, 80},                // base cell 68
+	{69, 51, 64, 47, 89, 71, 84},                // base cell 69
+	{70, 67, 52, 50, 83, 87, 74},                // base cell 70
+	{71, 89, 73, 91, 51, 69, 54},                // base cell 71
+	{72, invalidBaseCell, 73, 55, 80, 60, 88},   // base cell 72 (pentagon)
+	{73, 91, 72, 88, 54, 71, 55},                // base cell 73
+	{74, 78, 83, 92, 52, 57, 70},                // base cell 74
+	{75, 65, 61, 53, 94, 86, 81},                // base cell 75
+	{76, 86, 82, 96, 58, 65, 62},                // base cell 76
+	{77, 63, 68, 56, 93, 79, 90},                // base cell 77
+	{78, 74, 59, 57, 95, 92, 79},                // base cell 78
+	{79, 78, 63, 59, 93, 95, 77},                // base cell 79
+	{80, 68, 72, 60, 99, 90, 88},                // base cell 80
+	{81, 85, 94, 101, 61, 66, 75},               // base cell 81
+	{82, 96, 84, 98, 62, 76, 64},                // base cell 82
+	{83, invalidBaseCell, 74, 70, 100, 87, 92},  // base cell 83 (pentagon)
+	{84, 69, 82, 64, 97, 89, 98},                // base cell 84
+	{85, 87, 101, 102, 66, 67, 81},              // base cell 85
+	{86, 76, 75, 65, 104, 96, 94},               // base cell 86
+	{87, 83, 102, 100, 67, 70, 85},              // base cell 87
+	{88, 72, 91, 73, 99, 80, 105},               // base cell 88
+	{89, 97, 91, 103, 69, 84, 71},               // base cell 89
+	{90, 77, 80, 68, 106, 93, 99},               // base cell 90
+	{91, 73, 89, 71, 105, 88, 103},              // base cell 91
+	{92, 83, 78, 74, 108, 100, 95},              // base cell 92
+	{93, 79, 90, 77, 109, 95, 106},              // base cell 93
+	{94, 86, 81, 75, 107, 104, 101},             // base cell 94
+	{95, 92, 79, 78, 109, 108, 93},              // base cell 95
+	{96, 104, 98, 110, 76, 86, 82},              // base cell 96
+	{97, invalidBaseCell, 98, 84, 103, 89, 111}, // base cell 97 (pentagon)
+	{98, 110, 97, 111, 82, 96, 84},              // base cell 98
+	{99, 80, 105, 88, 106, 90, 113},             // base cell 99
+	{100, 102, 83, 87, 108, 114, 92},            // base cell 100
+	{101, 102, 107, 112, 81, 85, 94},            // base cell 101
+	{102, 101, 87, 85, 114, 112, 100},           // base cell 102
+	{103, 91, 97, 89, 116, 105, 111},            // base cell 103
+	{104, 107, 110, 115, 86, 94, 96},            // base cell 104
+	{105, 88, 103, 91, 113, 99, 116},            // base cell 105
+	{106, 93, 99, 90, 117, 109, 113},            // base cell 106
+	{107, invalidBaseCell, 101, 94, 115, 104,
+		112}, // base cell 107 (pentagon)
+	{108, 100, 95, 92, 118, 114, 109},   // base cell 108
+	{109, 108, 93, 95, 117, 118, 106},   // base cell 109
+	{110, 98, 104, 96, 119, 111, 115},   // base cell 110
+	{111, 97, 110, 98, 116, 103, 119},   // base cell 111
+	{112, 107, 102, 101, 120, 115, 114}, // base cell 112
+	{113, 99, 116, 105, 117, 106, 121},  // base cell 113
+	{114, 112, 100, 102, 118, 120, 108}, // base cell 114
+	{115, 110, 107, 104, 120, 119, 112}, // base cell 115
+	{116, 103, 119, 111, 113, 105, 121}, // base cell 116
+	{117, invalidBaseCell, 109, 118, 113, 121,
+		106}, // base cell 117 (pentagon)
+	{118, 120, 108, 114, 117, 121, 109}, // base cell 118
+	{119, 111, 115, 110, 121, 116, 120}, // base cell 119
+	{120, 115, 114, 112, 121, 119, 118}, // base cell 120
+	{121, 116, 120, 119, 117, 113, 118}, // base cell 121
+}
+
+// baseCellNeighbor60CCWRots[baseCell][dir] is the number of 60° ccw rotations
+// to apply when stepping from baseCell in direction dir.
+var baseCellNeighbor60CCWRots = [numBaseCells][7]int{
+	{0, 5, 0, 0, 1, 5, 1},  // base cell 0
+	{0, 0, 1, 0, 1, 0, 1},  // base cell 1
+	{0, 0, 0, 0, 0, 5, 0},  // base cell 2
+	{0, 5, 0, 0, 2, 5, 1},  // base cell 3
+	{0, -1, 1, 0, 3, 4, 2}, // base cell 4 (pentagon)
+	{0, 0, 1, 0, 1, 0, 1},  // base cell 5
+	{0, 0, 0, 3, 5, 5, 0},  // base cell 6
+	{0, 0, 0, 0, 0, 5, 0},  // base cell 7
+	{0, 5, 0, 0, 0, 5, 1},  // base cell 8
+	{0, 0, 1, 3, 0, 0, 1},  // base cell 9
+	{0, 0, 1, 3, 0, 0, 1},  // base cell 10
+	{0, 3, 3, 3, 0, 0, 0},  // base cell 11
+	{0, 5, 0, 0, 3, 5, 1},  // base cell 12
+	{0, 0, 1, 0, 1, 0, 1},  // base cell 13
+	{0, -1, 3, 0, 5, 2, 0}, // base cell 14 (pentagon)
+	{0, 5, 0, 0, 4, 5, 1},  // base cell 15
+	{0, 0, 0, 0, 0, 5, 0},  // base cell 16
+	{0, 3, 3, 3, 3, 0, 3},  // base cell 17
+	{0, 0, 0, 3, 5, 5, 0},  // base cell 18
+	{0, 3, 3, 3, 0, 0, 0},  // base cell 19
+	{0, 3, 3, 3, 0, 3, 0},  // base cell 20
+	{0, 0, 0, 3, 5, 5, 0},  // base cell 21
+	{0, 0, 1, 0, 1, 0, 1},  // base cell 22
+	{0, 3, 3, 3, 0, 3, 0},  // base cell 23
+	{0, -1, 3, 0, 5, 2, 0}, // base cell 24 (pentagon)
+	{0, 0, 0, 3, 0, 0, 3},  // base cell 25
+	{0, 0, 0, 0, 0, 5, 0},  // base cell 26
+	{0, 3, 0, 0, 0, 3, 3},  // base cell 27
+	{0, 0, 1, 0, 1, 0, 1},  // base cell 28
+	{0, 0, 1, 3, 0, 0, 1},  // base cell 29
+	{0, 3, 3, 3, 0, 0, 0},  // base cell 30
+	{0, 0, 0, 0, 0, 5, 0},  // base cell 31
+	{0, 3, 3, 3, 3, 0, 3},  // base cell 32
+	{0, 0, 1, 3, 0, 0, 1},  // base cell 33
+	{0, 3, 3, 3, 3, 0, 3},  // base cell 34
+	{0, 0, 3, 0, 3, 0, 3},  // base cell 35
+	{0, 0, 0, 3, 0, 0, 3},  // base cell 36
+	{0, 3, 0, 0, 0, 3, 3},  // base cell 37
+	{0, -1, 3, 0, 5, 2, 0}, // base cell 38 (pentagon)
+	{0, 3, 0, 0, 3, 3, 0},  // base cell 39
+	{0, 3, 0, 0, 3, 3, 0},  // base cell 40
+	{0, 0, 0, 3, 5, 5, 0},  // base cell 41
+	{0, 0, 0, 3, 5, 5, 0},  // base cell 42
+	{0, 3, 3, 3, 0, 0, 0},  // base cell 43
+	{0, 0, 1, 3, 0, 0, 1},  // base cell 44
+	{0, 0, 3, 0, 0, 3, 3},  // base cell 45
+	{0, 0, 0, 3, 0, 3, 0},  // base cell 46
+	{0, 3, 3, 3, 0, 3, 0},  // base cell 47
+	{0, 3, 3, 3, 0, 3, 0},  // base cell 48
+	{0, -1, 3, 0, 5, 2, 0}, // base cell 49 (pentagon)
+	{0, 0, 0, 3, 0, 0, 3},  // base cell 50
+	{0, 3, 0, 0, 0, 3, 3},  // base cell 51
+	{0, 0, 3, 0, 3, 0, 3},  // base cell 52
+	{0, 3, 3, 3, 0, 0, 0},  // base cell 53
+	{0, 0, 3, 0, 3, 0, 3},  // base cell 54
+	{0, 0, 3, 0, 0, 3, 3},  // base cell 55
+	{0, 3, 3, 3, 0, 0, 3},  // base cell 56
+	{0, 0, 0, 3, 0, 3, 0},  // base cell 57
+	{0, -1, 3, 0, 5, 2, 0}, // base cell 58 (pentagon)
+	{0, 3, 3, 3, 3, 3, 0},  // base cell 59
+	{0, 3, 3, 3, 3, 3, 0},  // base cell 60
+	{0, 3, 3, 3, 3, 0, 3},  // base cell 61
+	{0, 3, 3, 3, 3, 0, 3},  // base cell 62
+	{0, -1, 3, 0, 5, 2, 0}, // base cell 63 (pentagon)
+	{0, 0, 0, 3, 0, 0, 3},  // base cell 64
+	{0, 3, 3, 3, 0, 3, 0},  // base cell 65
+	{0, 3, 0, 0, 0, 3, 3},  // base cell 66
+	{0, 3, 0, 0, 3, 3, 0},  // base cell 67
+	{0, 3, 3, 3, 0, 0, 0},  // base cell 68
+	{0, 3, 0, 0, 3, 3, 0},  // base cell 69
+	{0, 0, 3, 0, 0, 3, 3},  // base cell 70
+	{0, 0, 0, 3, 0, 3, 0},  // base cell 71
+	{0, -1, 3, 0, 5, 2, 0}, // base cell 72 (pentagon)
+	{0, 3, 3, 3, 0, 0, 3},  // base cell 73
+	{0, 3, 3, 3, 0, 0, 3},  // base cell 74
+	{0, 0, 0, 3, 0, 0, 3},  // base cell 75
+	{0, 3, 0, 0, 0, 3, 3},  // base cell 76
+	{0, 0, 0, 3, 0, 5, 0},  // base cell 77
+	{0, 3, 3, 3, 0, 0, 0},  // base cell 78
+	{0, 0, 1, 3, 1, 0, 1},  // base cell 79
+	{0, 0, 1, 3, 1, 0, 1},  // base cell 80
+	{0, 0, 3, 0, 3, 0, 3},  // base cell 81
+	{0, 0, 3, 0, 3, 0, 3},  // base cell 82
+	{0, -1, 3, 0, 5, 2, 0}, // base cell 83 (pentagon)
+	{0, 0, 3, 0, 0, 3, 3},  // base cell 84
+	{0, 0, 0, 3, 0, 3, 0},  // base cell 85
+	{0, 3, 0, 0, 3, 3, 0},  // base cell 86
+	{0, 3, 3, 3, 3, 3, 0},  // base cell 87
+	{0, 0, 0, 3, 0, 5, 0},  // base cell 88
+	{0, 3, 3, 3, 3, 3, 0},  // base cell 89
+	{0, 0, 0, 0, 0, 0, 1},  // base cell 90
+	{0, 3, 3, 3, 0, 0, 0},  // base cell 91
+	{0, 0, 0, 3, 0, 5, 0},  // base cell 92
+	{0, 5, 0, 0, 5, 5, 0},  // base cell 93
+	{0, 0, 3, 0, 0, 3, 3},  // base cell 94
+	{0, 0, 0, 0, 0, 0, 1},  // base cell 95
+	{0, 0, 0, 3, 0, 3, 0},  // base cell 96
+	{0, -1, 3, 0, 5, 2, 0}, // base cell 97 (pentagon)
+	{0, 3, 3, 3, 0, 0, 3},  // base cell 98
+	{0, 5, 0, 0, 5, 5, 0},  // base cell 99
+	{0, 0, 1, 3, 1, 0, 1},  // base cell 100
+	{0, 3, 3, 3, 0, 0, 3},  // base cell 101
+	{0, 3, 3, 3, 0, 0, 0},  // base cell 102
+	{0, 0, 1, 3, 1, 0, 1},  // base cell 103
+	{0, 3, 3, 3, 3, 3, 0},  // base cell 104
+	{0, 0, 0, 0, 0, 0, 1},  // base cell 105
+	{0, 0, 1, 0, 3, 5, 1},  // base cell 106
+	{0, -1, 3, 0, 5, 2, 0}, // base cell 107 (pentagon)
+	{0, 5, 0, 0, 5, 5, 0},  // base cell 108
+	{0, 0, 1, 0, 4, 5, 1},  // base cell 109
+	{0, 3, 3, 3, 0, 0, 0},  // base cell 110
+	{0, 0, 0, 3, 0, 5, 0},  // base cell 111
+	{0, 0, 0, 3, 0, 5, 0},  // base cell 112
+	{0, 0, 1, 0, 2, 5, 1},  // base cell 113
+	{0, 0, 0, 0, 0, 0, 1},  // base cell 114
+	{0, 0, 1, 3, 1, 0, 1},  // base cell 115
+	{0, 5, 0, 0, 5, 5, 0},  // base cell 116
+	{0, -1, 1, 0, 3, 4, 2}, // base cell 117 (pentagon)
+	{0, 0, 1, 0, 0, 5, 1},  // base cell 118
+	{0, 0, 0, 0, 0, 0, 1},  // base cell 119
+	{0, 5, 0, 0, 5, 5, 0},  // base cell 120
+	{0, 0, 1, 0, 1, 5, 1},  // base cell 121
 }

--- a/x/h3go/index.go
+++ b/x/h3go/index.go
@@ -87,6 +87,14 @@ func (c Cell) setIndexDigit(res, digit int) Cell {
 	return c
 }
 
+// setBaseCell returns the index with its base cell field set to baseCell.
+func (c Cell) setBaseCell(baseCell int) Cell {
+	c &= ^(Cell(baseCellMask) << baseCellOffset)
+	c |= Cell(baseCell) << baseCellOffset
+
+	return c
+}
+
 // BaseCellNumber returns the integer ID (0-121) of the base cell the cell
 // belongs to.
 func BaseCellNumber(c Cell) int {

--- a/x/h3go/paritytest/grid_test.go
+++ b/x/h3go/paritytest/grid_test.go
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2026 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package paritytest
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/uber/h3-go/v4"
+	"github.com/uber/h3-go/v4/x/h3go"
+)
+
+// gridKValues is the set of grid distances exercised by the traversal parity
+// tests, spanning the origin-only case through a few full rings.
+var gridKValues = []int{0, 1, 2, 3, 5}
+
+// dropZeros returns the non-zero cells of in. The cgo reference leaves zero
+// slots in its grid output when crossing pentagons or sizing for the worst
+// case; the pure-Go implementation emits only real cells, so parity is compared
+// as sets after removing zeros.
+func dropZeros(in []h3go.Cell) []h3go.Cell {
+	out := make([]h3go.Cell, 0, len(in))
+	for _, c := range in {
+		if c != 0 {
+			out = append(out, c)
+		}
+	}
+
+	return out
+}
+
+// assertSameRings fails if two ringed grid results differ ring-by-ring as sets,
+// ignoring order and zero padding.
+func assertSameRings(t *testing.T, got [][]h3go.Cell, want [][]h3.Cell, msg string) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("%s: ring count got=%d want=%d", msg, len(got), len(want))
+	}
+
+	for ring := range got {
+		assertSameCellSet(t, dropZeros(got[ring]), dropZeros(toGoCells(want[ring])), msg)
+	}
+}
+
+// TestGridDiskMatchesCgo asserts the flat disk, ringed distances, and their
+// unsafe/safe variants match the cgo reference (as zero-pruned sets) over the
+// corpus and a range of k values, including error parity.
+func TestGridDiskMatchesCgo(t *testing.T) {
+	t.Parallel()
+
+	for _, ref := range referenceCorpus(t) {
+		goCell := h3goCell(ref)
+
+		for _, k := range gridKValues {
+			wantDisk, wantErr := h3.GridDisk(ref, k)
+			gotDisk, gotErr := h3go.GridDisk(goCell, k)
+
+			if !bothErr(wantErr, gotErr) {
+				t.Fatalf("GridDisk(%015x, %d) error mismatch: cgo=%v h3go=%v", uint64(ref), k, wantErr, gotErr)
+			}
+
+			if wantErr == nil {
+				assertSameCellSet(t, dropZeros(gotDisk), dropZeros(toGoCells(wantDisk)), "GridDisk")
+			}
+
+			wantSafe, _ := h3.GridDiskDistancesSafe(ref, k)
+
+			gotSafe, gotSafeErr := h3go.GridDiskDistancesSafe(goCell, k)
+			if gotSafeErr != nil {
+				t.Fatalf("GridDiskDistancesSafe(%015x, %d): %v", uint64(ref), k, gotSafeErr)
+			}
+
+			assertSameRings(t, gotSafe, wantSafe, "GridDiskDistancesSafe")
+
+			wantAuto, _ := h3.GridDiskDistances(ref, k)
+
+			gotAuto, gotAutoErr := h3go.GridDiskDistances(goCell, k)
+			if gotAutoErr != nil {
+				t.Fatalf("GridDiskDistances(%015x, %d): %v", uint64(ref), k, gotAutoErr)
+			}
+
+			assertSameRings(t, gotAuto, wantAuto, "GridDiskDistances")
+
+			wantUnsafe, wantUnsafeErr := h3.GridDiskDistancesUnsafe(ref, k)
+			gotUnsafe, gotUnsafeErr := h3go.GridDiskDistancesUnsafe(goCell, k)
+
+			if !bothErr(wantUnsafeErr, gotUnsafeErr) {
+				t.Fatalf("GridDiskDistancesUnsafe(%015x, %d) error mismatch: cgo=%v h3go=%v", uint64(ref), k, wantUnsafeErr, gotUnsafeErr)
+			}
+
+			if wantUnsafeErr == nil {
+				assertSameRings(t, gotUnsafe, wantUnsafe, "GridDiskDistancesUnsafe")
+			}
+		}
+	}
+}
+
+// TestGridRingMatchesCgo asserts the hollow-ring variants match the cgo
+// reference (as zero-pruned sets), including error parity for the unsafe form.
+func TestGridRingMatchesCgo(t *testing.T) {
+	t.Parallel()
+
+	for _, ref := range referenceCorpus(t) {
+		goCell := h3goCell(ref)
+
+		for _, k := range gridKValues {
+			wantRing, wantErr := h3.GridRing(ref, k)
+			gotRing, gotErr := h3go.GridRing(goCell, k)
+
+			if !bothErr(wantErr, gotErr) {
+				t.Fatalf("GridRing(%015x, %d) error mismatch: cgo=%v h3go=%v", uint64(ref), k, wantErr, gotErr)
+			}
+
+			if wantErr == nil {
+				assertSameCellSet(t, dropZeros(gotRing), dropZeros(toGoCells(wantRing)), "GridRing")
+			}
+
+			wantUnsafe, wantUnsafeErr := h3.GridRingUnsafe(ref, k)
+			gotUnsafe, gotUnsafeErr := h3go.GridRingUnsafe(goCell, k)
+
+			if !bothErr(wantUnsafeErr, gotUnsafeErr) {
+				t.Fatalf("GridRingUnsafe(%015x, %d) error mismatch: cgo=%v h3go=%v", uint64(ref), k, wantUnsafeErr, gotUnsafeErr)
+			}
+
+			if wantUnsafeErr == nil {
+				assertSameCellSet(t, dropZeros(gotUnsafe), dropZeros(toGoCells(wantUnsafe)), "GridRingUnsafe")
+			}
+		}
+	}
+}
+
+// TestGridDisksUnsafeMatchesCgo asserts the batch disk traversal matches the cgo
+// reference per origin (as zero-pruned sets), including error parity.
+func TestGridDisksUnsafeMatchesCgo(t *testing.T) {
+	t.Parallel()
+
+	corpus := referenceCorpus(t)
+
+	for _, k := range gridKValues {
+		want, wantErr := h3.GridDisksUnsafe(corpus, k)
+		got, gotErr := h3go.GridDisksUnsafe(toGoCells(corpus), k)
+
+		if !bothErr(wantErr, gotErr) {
+			t.Fatalf("GridDisksUnsafe(k=%d) error mismatch: cgo=%v h3go=%v", k, wantErr, gotErr)
+		}
+
+		if wantErr != nil {
+			continue
+		}
+
+		if len(got) != len(want) {
+			t.Fatalf("GridDisksUnsafe(k=%d): outer len got=%d want=%d", k, len(got), len(want))
+		}
+
+		for i := range got {
+			assertSameCellSet(t, dropZeros(got[i]), dropZeros(toGoCells(want[i])), "GridDisksUnsafe")
+		}
+	}
+}
+
+// TestIsNeighborMatchesCgo asserts neighbor detection matches the cgo reference
+// for bool and error, covering true neighbors (each cell against its ring-1
+// cells), non-neighbors, and resolution-mismatched pairs.
+func TestIsNeighborMatchesCgo(t *testing.T) {
+	t.Parallel()
+
+	corpus := referenceCorpus(t)
+
+	for _, ref := range corpus {
+		neighbors, err := h3.GridDisk(ref, 1)
+		if err != nil {
+			continue
+		}
+
+		others := append(slices.Clone(neighbors), corpus...)
+		for _, other := range others {
+			if other == 0 {
+				continue
+			}
+
+			wantNeighbor, wantErr := ref.IsNeighbor(other)
+			gotNeighbor, gotErr := h3goCell(ref).IsNeighbor(h3goCell(other))
+
+			if !bothErr(wantErr, gotErr) {
+				t.Fatalf("IsNeighbor(%015x, %015x) error mismatch: cgo=%v h3go=%v", uint64(ref), uint64(other), wantErr, gotErr)
+			}
+
+			if wantErr == nil && wantNeighbor != gotNeighbor {
+				t.Fatalf("IsNeighbor(%015x, %015x): cgo=%v h3go=%v", uint64(ref), uint64(other), wantNeighbor, gotNeighbor)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Implement the grid traversal family in pure Go, verified against the cgo reference:

- GridDisk (+ method), GridDisksUnsafe
- GridDiskDistances / Unsafe / Safe (+ methods)
- GridRing / GridRingUnsafe (+ methods)
- Cell.IsNeighbor

The core is neighborRotations, which steps to an adjacent cell while threading base-cell rotation state and pentagon distortion. The fast ("Unsafe") spiral fails near pentagons and falls back to a breadth-first "Safe" traversal. Adds the base-cell neighbor/rotation tables and the Class II/III digit-adjustment tables, plus ErrPentagon and a setBaseCell helper.