### PR TITLE
feat: add pure-Go local IJ coordinates & grid metrics to x/h3go

### DIFF
--- a/x/h3go/faceijk.go
+++ b/x/h3go/faceijk.go
@@ -227,6 +227,49 @@ func (c coordIJK) rotate60cw() coordIJK {
 	return out
 }
 
+// sub returns the component-wise difference c - b.
+func (c coordIJK) sub(b coordIJK) coordIJK {
+	return coordIJK{i: c.i - b.i, j: c.j - b.j, k: c.k - b.k}
+}
+
+// distance returns the grid distance between two IJK coordinates: the largest
+// component of their normalized difference (normalization leaves all components
+// non-negative).
+func (c coordIJK) distance(b coordIJK) int {
+	diff := c.sub(b)
+	diff.normalize()
+
+	return max(diff.i, diff.j, diff.k)
+}
+
+// unitToDigit maps an IJK coordinate to its digit if, once normalized, it is the
+// center or one of the six unit neighbors, returning invalidDigit otherwise.
+func (c coordIJK) unitToDigit() int {
+	c.normalize()
+
+	if c.i < 0 || c.i > 1 || c.j < 0 || c.j > 1 || c.k < 0 || c.k > 1 {
+		return invalidDigit
+	}
+
+	return unitIjkToDigitLUT[c.i][c.j][c.k]
+}
+
+// toCube converts an IJK coordinate in place to cube coordinates, suitable for
+// linear interpolation along a grid line.
+func (c *coordIJK) toCube() {
+	c.i = -c.i + c.k
+	c.j = c.j - c.k
+	c.k = -c.i - c.j
+}
+
+// fromCube converts cube coordinates in place back to a normalized IJK
+// coordinate, the inverse of toCube.
+func (c *coordIJK) fromCube() {
+	c.i = -c.i
+	c.k = 0
+	c.normalize()
+}
+
 // downAp3 transforms an IJK coordinate to the next finer resolution on the
 // Class II aperture-3 substrate grid (counterclockwise), then re-normalizes.
 func (c *coordIJK) downAp3() {
@@ -521,6 +564,27 @@ func (c Cell) rotatePent60ccw() Cell {
 
 			if c.leadingNonZeroDigit() == kAxesDigit {
 				c = c.rotate60ccw()
+			}
+		}
+	}
+
+	return c
+}
+
+// rotatePent60cw rotates c 60° clockwise about a pentagon base cell center,
+// skipping the deleted k-axis subsequence as the leading digit is first
+// encountered so the index stays canonical.
+func (c Cell) rotatePent60cw() Cell {
+	foundFirstNonZero := false
+
+	for r := 1; r <= c.Resolution(); r++ {
+		c = c.setIndexDigit(r, rotate60cw(c.indexDigit(r)))
+
+		if !foundFirstNonZero && c.indexDigit(r) != centerDigit {
+			foundFirstNonZero = true
+
+			if c.leadingNonZeroDigit() == kAxesDigit {
+				c = c.rotate60cw()
 			}
 		}
 	}

--- a/x/h3go/h3go.go
+++ b/x/h3go/h3go.go
@@ -134,6 +134,7 @@ const (
 	ikAxesDigit  = 5
 	ijAxesDigit  = 6
 	invalidDigit = 7
+	numDigits    = 7
 
 	// H3 index bit-layout offsets and masks, shared with the cgo h3 package.
 	cellMode         = h3core.CellMode
@@ -891,4 +892,69 @@ var baseCellNeighbor60CCWRots = [numBaseCells][7]int{
 	{0, 0, 0, 0, 0, 0, 1},  // base cell 119
 	{0, 5, 0, 0, 5, 5, 0},  // base cell 120
 	{0, 0, 1, 0, 1, 5, 1},  // base cell 121
+}
+
+// pentagonRotations maps the base-cell direction (or leading digit) to the
+// number of 60° clockwise index rotations needed when unfolding a pentagon,
+// indexed by [origin leading digit][direction]. A -1 marks an invalid k-axis
+// combination.
+var pentagonRotations = [7][7]int{
+	{0, -1, 0, 0, 0, 0, 0},
+	{-1, -1, -1, -1, -1, -1, -1},
+	{0, -1, 0, 0, 0, 1, 0},
+	{0, -1, 0, 0, 1, 1, 0},
+	{0, -1, 0, 5, 0, 0, 0},
+	{0, -1, 5, 5, 0, 0, 0},
+	{0, -1, 0, 0, 0, 0, 0},
+}
+
+// pentagonRotationsReverse reverses the rotation pentagonRotations introduces
+// when the origin is on a pentagon, indexed by [leading digit][direction].
+var pentagonRotationsReverse = [7][7]int{
+	{0, 0, 0, 0, 0, 0, 0},
+	{-1, -1, -1, -1, -1, -1, -1},
+	{0, 1, 0, 0, 0, 0, 0},
+	{0, 1, 0, 0, 0, 1, 0},
+	{0, 5, 0, 0, 0, 0, 0},
+	{0, 5, 0, 5, 0, 0, 0},
+	{0, 0, 0, 0, 0, 0, 0},
+}
+
+// pentagonRotationsReverseNonpolar reverses the pentagon rotation when the index
+// is on a non-polar pentagon and the origin is not, indexed by
+// [reverse direction][leading digit].
+var pentagonRotationsReverseNonpolar = [7][7]int{
+	{0, 0, 0, 0, 0, 0, 0},
+	{-1, -1, -1, -1, -1, -1, -1},
+	{0, 1, 0, 0, 0, 0, 0},
+	{0, 1, 0, 0, 0, 1, 0},
+	{0, 5, 0, 0, 0, 0, 0},
+	{0, 1, 0, 5, 1, 1, 0},
+	{0, 0, 0, 0, 0, 0, 0},
+}
+
+// pentagonRotationsReversePolar reverses the pentagon rotation when the index is
+// on a polar pentagon and the origin is not, indexed by
+// [reverse direction][leading digit].
+var pentagonRotationsReversePolar = [7][7]int{
+	{0, 0, 0, 0, 0, 0, 0},
+	{-1, -1, -1, -1, -1, -1, -1},
+	{0, 1, 1, 1, 1, 1, 1},
+	{0, 1, 0, 0, 0, 1, 0},
+	{0, 1, 0, 0, 1, 1, 1},
+	{0, 1, 0, 5, 1, 1, 0},
+	{0, 1, 1, 0, 1, 1, 1},
+}
+
+// failedDirections marks the direction pairs that cannot be unfolded across a
+// pentagon (any unfolding across more than one icosahedron face), indexed by
+// [origin direction][index direction].
+var failedDirections = [7][7]bool{
+	{false, false, false, false, false, false, false},
+	{false, false, false, false, false, false, false},
+	{false, false, false, false, true, true, false},
+	{false, false, false, false, true, false, true},
+	{false, false, true, true, false, false, false},
+	{false, false, true, false, false, false, true},
+	{false, false, false, true, false, true, false},
 }

--- a/x/h3go/localij.go
+++ b/x/h3go/localij.go
@@ -1,0 +1,489 @@
+/*
+ * Copyright 2026 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package h3go
+
+import (
+	"cmp"
+	"math"
+
+	"github.com/uber/h3-go/v4/internal/h3core"
+)
+
+// CoordIJ holds IJ hexagon coordinates anchored at an origin cell. The two axes
+// are spaced 120° apart. Coordinates are only comparable when produced from the
+// same origin, and the encoding is not guaranteed stable across H3 versions.
+type CoordIJ struct {
+	I, J int
+}
+
+// getBaseCellDirection returns the digit direction from one base cell to a
+// neighboring base cell, or invalidDigit if they are not neighbors.
+func getBaseCellDirection(originBaseCell, neighborBaseCell int) int {
+	for dir := centerDigit; dir < numDigits; dir++ {
+		if baseCellNeighbors[originBaseCell][dir] == neighborBaseCell {
+			return dir
+		}
+	}
+
+	return invalidDigit
+}
+
+// cubeRound rounds floating-point cube coordinates to the nearest valid integer
+// cube coordinate (where i+j+k == 0), per the standard hex rounding algorithm.
+func cubeRound(iCoord, jCoord, kCoord float64) coordIJK {
+	roundI := int(math.Round(iCoord))
+	roundJ := int(math.Round(jCoord))
+	roundK := int(math.Round(kCoord))
+
+	iDiff := math.Abs(float64(roundI) - iCoord)
+	jDiff := math.Abs(float64(roundJ) - jCoord)
+	kDiff := math.Abs(float64(roundK) - kCoord)
+
+	switch {
+	case iDiff > jDiff && iDiff > kDiff:
+		roundI = -roundJ - roundK
+	case jDiff > kDiff:
+		roundJ = -roundI - roundK
+	default:
+		roundK = -roundI - roundJ
+	}
+
+	return coordIJK{i: roundI, j: roundJ, k: roundK}
+}
+
+// cellToLocalIjk returns the IJK coordinates of target in the coordinate system
+// anchored at c (the origin). The coordinate space may have deleted regions or
+// pentagon warping, so it can fail when target is too far from the origin or on
+// the far side of a pentagon.
+func (c Cell) cellToLocalIjk(target Cell) (coordIJK, error) {
+	res := c.Resolution()
+	if res != target.Resolution() {
+		return coordIJK{}, ErrResolutionMismatch
+	}
+
+	originBaseCell := c.BaseCellNumber()
+	baseCell := target.BaseCellNumber()
+
+	if originBaseCell >= numBaseCells || baseCell >= numBaseCells {
+		return coordIJK{}, ErrCellInvalid
+	}
+
+	// Direction from origin base cell to the target base cell (and back).
+	dir := centerDigit
+	revDir := centerDigit
+
+	if originBaseCell != baseCell {
+		dir = getBaseCellDirection(originBaseCell, baseCell)
+		if dir == invalidDigit {
+			return coordIJK{}, ErrFailed
+		}
+
+		revDir = getBaseCellDirection(baseCell, originBaseCell)
+	}
+
+	originOnPent := h3core.IsBaseCellPentagon[originBaseCell]
+	indexOnPent := h3core.IsBaseCellPentagon[baseCell]
+
+	index := target
+
+	if dir != centerDigit {
+		// Rotate the target into the origin base cell's orientation, undoing the
+		// rotation into that base cell (hence clockwise).
+		baseCellRotations := baseCellNeighbor60CCWRots[originBaseCell][dir]
+		if indexOnPent {
+			for range baseCellRotations {
+				index = index.rotatePent60cw()
+
+				revDir = rotate60cw(revDir)
+				if revDir == kAxesDigit {
+					revDir = rotate60cw(revDir)
+				}
+			}
+		} else {
+			for range baseCellRotations {
+				index = index.rotate60cw()
+				revDir = rotate60cw(revDir)
+			}
+		}
+	}
+
+	// Face is unused: this produces coordinates in base cell coordinate space.
+	fijk, _ := index.toFaceIjkWithInitializedFijk(faceIJK{})
+	coord := fijk.coord
+
+	switch {
+	case dir != centerDigit:
+		pentagonRots := 0
+		directionRots := 0
+
+		if originOnPent {
+			originLeadingDigit := c.leadingNonZeroDigit()
+			if originLeadingDigit == invalidDigit {
+				return coordIJK{}, ErrCellInvalid
+			}
+
+			if failedDirections[originLeadingDigit][dir] {
+				return coordIJK{}, ErrFailed
+			}
+
+			directionRots = pentagonRotations[originLeadingDigit][dir]
+			pentagonRots = directionRots
+		} else if indexOnPent {
+			indexLeadingDigit := index.leadingNonZeroDigit()
+			if indexLeadingDigit == invalidDigit {
+				return coordIJK{}, ErrCellInvalid
+			}
+
+			if failedDirections[indexLeadingDigit][revDir] {
+				return coordIJK{}, ErrFailed
+			}
+
+			pentagonRots = pentagonRotations[revDir][indexLeadingDigit]
+		}
+
+		if pentagonRots < 0 || directionRots < 0 {
+			return coordIJK{}, ErrCellInvalid
+		}
+
+		for range pentagonRots {
+			coord = coord.rotate60cw()
+		}
+
+		offset := coordIJK{}.neighbor(dir)
+		// Scale the offset to the index resolution.
+		for r := res - 1; r >= 0; r-- {
+			if isResClassIII(r + 1) {
+				offset.downAp7()
+			} else {
+				offset.downAp7r()
+			}
+		}
+
+		for range directionRots {
+			offset = offset.rotate60cw()
+		}
+
+		coord = coord.add(offset)
+		coord.normalize()
+	case originOnPent && indexOnPent:
+		// Same pentagon base cell.
+		originLeadingDigit := c.leadingNonZeroDigit()
+		indexLeadingDigit := index.leadingNonZeroDigit()
+
+		if originLeadingDigit == invalidDigit || indexLeadingDigit == invalidDigit {
+			return coordIJK{}, ErrCellInvalid
+		}
+
+		if failedDirections[originLeadingDigit][indexLeadingDigit] {
+			return coordIJK{}, ErrFailed
+		}
+
+		withinPentagonRots := pentagonRotations[originLeadingDigit][indexLeadingDigit]
+		for range withinPentagonRots {
+			coord = coord.rotate60cw()
+		}
+	}
+
+	return coord, nil
+}
+
+// localIjkToCell returns the cell at the given IJK coordinates in the coordinate
+// system anchored at c (the origin). It can fail when the coordinates are too
+// far from the origin or on the far side of a pentagon.
+func (c Cell) localIjkToCell(ijk coordIJK) (Cell, error) {
+	res := c.Resolution()
+
+	originBaseCell := c.BaseCellNumber()
+	if originBaseCell >= numBaseCells {
+		return 0, ErrCellInvalid
+	}
+
+	originOnPent := h3core.IsBaseCellPentagon[originBaseCell]
+
+	out := Cell(h3Init) | Cell(cellMode)<<modeOffset
+	out = out.setResolution(res)
+
+	// res 0 / base cell case.
+	if res == 0 {
+		dir := ijk.unitToDigit()
+		if dir == invalidDigit {
+			return 0, ErrFailed
+		}
+
+		newBaseCell := baseCellNeighbors[originBaseCell][dir]
+		if newBaseCell == invalidBaseCell {
+			return 0, ErrFailed
+		}
+
+		return out.setBaseCell(newBaseCell), nil
+	}
+
+	// Build the index digits from finest resolution up, recovering the base
+	// cell's IJK in its own coordinate system in ijkCopy.
+	ijkCopy := ijk
+	for r := res - 1; r >= 0; r-- {
+		lastIJK := ijkCopy
+
+		var lastCenter coordIJK
+
+		if isResClassIII(r + 1) {
+			ijkCopy.upAp7()
+			lastCenter = ijkCopy
+			lastCenter.downAp7()
+		} else {
+			ijkCopy.upAp7r()
+			lastCenter = ijkCopy
+			lastCenter.downAp7r()
+		}
+
+		diff := lastIJK.sub(lastCenter)
+		diff.normalize()
+		out = out.setIndexDigit(r+1, diff.unitToDigit())
+	}
+
+	if ijkCopy.i > 1 || ijkCopy.j > 1 || ijkCopy.k > 1 {
+		return 0, ErrFailed
+	}
+
+	dir := ijkCopy.unitToDigit()
+	baseCell := baseCellNeighbors[originBaseCell][dir]
+
+	indexOnPent := false
+	if baseCell != invalidBaseCell {
+		indexOnPent = h3core.IsBaseCellPentagon[baseCell]
+	}
+
+	switch {
+	case dir != centerDigit:
+		var err error
+
+		out, baseCell, err = c.localIjkToCellOffOrigin(out, dir, originBaseCell, baseCell, originOnPent, indexOnPent)
+		if err != nil {
+			return 0, err
+		}
+	case originOnPent && indexOnPent:
+		originLeadingDigit := c.leadingNonZeroDigit()
+		indexLeadingDigit := out.leadingNonZeroDigit()
+
+		if originLeadingDigit == invalidDigit || indexLeadingDigit == invalidDigit {
+			return 0, ErrCellInvalid
+		}
+
+		withinPentagonRots := pentagonRotationsReverse[originLeadingDigit][indexLeadingDigit]
+		if withinPentagonRots < 0 {
+			return 0, ErrCellInvalid
+		}
+
+		for range withinPentagonRots {
+			out = out.rotate60ccw()
+		}
+	}
+
+	if indexOnPent {
+		// Fail if the recovered index lands on the deleted k subsequence.
+		if out.leadingNonZeroDigit() == kAxesDigit {
+			return 0, ErrPentagon
+		}
+	}
+
+	return out.setBaseCell(baseCell), nil
+}
+
+// localIjkToCellOffOrigin applies the base-cell and pentagon rotations for the
+// case where the recovered coordinate moves off the origin base cell (the
+// direction is not the center). It returns the rotated partial cell and the
+// resolved destination base cell, or an error when the move crosses pentagon
+// distortion or lands on an invalid coordinate.
+func (c Cell) localIjkToCellOffOrigin(out Cell, dir, originBaseCell, baseCell int, originOnPent, indexOnPent bool) (Cell, int, error) {
+	pentagonRots := 0
+
+	if originOnPent {
+		originLeadingDigit := c.leadingNonZeroDigit()
+		if originLeadingDigit == invalidDigit {
+			return 0, 0, ErrCellInvalid
+		}
+
+		pentagonRots = pentagonRotationsReverse[originLeadingDigit][dir]
+		for range pentagonRots {
+			dir = rotate60ccw(dir)
+		}
+
+		// The pentagon rotations avoid the deleted direction; if we still land on
+		// it the coordinate crosses pentagon distortion.
+		if dir == kAxesDigit {
+			return 0, 0, ErrPentagon
+		}
+
+		baseCell = baseCellNeighbors[originBaseCell][dir]
+	}
+
+	baseCellRotations := baseCellNeighbor60CCWRots[originBaseCell][dir]
+	if indexOnPent {
+		revDir := getBaseCellDirection(baseCell, originBaseCell)
+
+		// Adjust for the two base cells' coordinate spaces first, so the pentagon
+		// rotations use the leading digit in pentagon space.
+		for range baseCellRotations {
+			out = out.rotate60ccw()
+		}
+
+		indexLeadingDigit := out.leadingNonZeroDigit()
+		if isBaseCellPolarPentagon(baseCell) {
+			pentagonRots = pentagonRotationsReversePolar[revDir][indexLeadingDigit]
+		} else {
+			pentagonRots = pentagonRotationsReverseNonpolar[revDir][indexLeadingDigit]
+		}
+
+		// A negative entry would require revDir to be the k axis, which is
+		// impossible from a pentagon index base cell, so a range over it simply
+		// does nothing here.
+		for range pentagonRots {
+			out = out.rotatePent60ccw()
+		}
+
+		return out, baseCell, nil
+	}
+
+	if pentagonRots < 0 {
+		return 0, 0, ErrCellInvalid
+	}
+
+	for range pentagonRots {
+		out = out.rotate60ccw()
+	}
+
+	for range baseCellRotations {
+		out = out.rotate60ccw()
+	}
+
+	return out, baseCell, nil
+}
+
+// CellToLocalIJ returns the IJ coordinates of cell anchored by origin. The
+// coordinate space may have deleted regions or pentagon warping, and is only
+// comparable for cells produced from the same origin.
+func CellToLocalIJ(origin, cell Cell) (CoordIJ, error) {
+	ijk, err := origin.cellToLocalIjk(cell)
+	if err != nil {
+		return CoordIJ{}, err
+	}
+
+	return CoordIJ{I: ijk.i - ijk.k, J: ijk.j - ijk.k}, nil
+}
+
+// LocalIJToCell returns the cell at the IJ coordinates anchored by origin. It is
+// the inverse of CellToLocalIJ, subject to the same pentagon and range limits.
+func LocalIJToCell(origin Cell, ij CoordIJ) (Cell, error) {
+	ijk := coordIJK{i: ij.I, j: ij.J, k: 0}
+	ijk.normalize()
+
+	return origin.localIjkToCell(ijk)
+}
+
+// GridDistance returns the grid distance (number of steps) between c and other,
+// or an error if the distance cannot be computed, such as when the cells are far
+// apart or on opposite sides of a pentagon.
+func (c Cell) GridDistance(other Cell) (int, error) {
+	originIjk, err := c.cellToLocalIjk(c)
+	if err != nil {
+		return 0, err
+	}
+
+	otherIjk, err := c.cellToLocalIjk(other)
+	if err != nil {
+		return 0, err
+	}
+
+	return originIjk.distance(otherIjk), nil
+}
+
+// GridDistance returns the grid distance between two cells.
+func GridDistance(a, b Cell) (int, error) {
+	return a.GridDistance(b)
+}
+
+// GridPath returns the line of cells from c to other inclusive. Consecutive
+// cells are neighbors and the line length is GridDistance+1. It can fail when
+// the distance cannot be computed or the line crosses pentagon distortion.
+func (c Cell) GridPath(other Cell) ([]Cell, error) {
+	distance, err := c.GridDistance(other)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]Cell, distance+1)
+	if distance == 0 {
+		out[0] = c
+		return out, nil
+	}
+
+	// Straight-line interpolation in local IJK space anchored at c.
+	if gridPathInterpolate(c, other, distance, out, 0, 1) == nil {
+		return out, nil
+	}
+
+	// The forward attempt can fail crossing pentagon distortion; retrying
+	// anchored at the other endpoint (filling in reverse) resolves those cases
+	// for any valid pair, so its result is returned directly.
+	return out, gridPathInterpolate(other, c, distance, out, distance, -1)
+}
+
+// GridPath returns the line of cells between two cells inclusive.
+func GridPath(a, b Cell) ([]Cell, error) {
+	return a.GridPath(b)
+}
+
+// gridPathInterpolate fills out with the line from start to end by interpolating
+// through the local IJK space anchored at start. out[outOffset + outStep*n]
+// receives the nth cell, so outStep of -1 fills the line in reverse. It fails if
+// an intermediate coordinate cannot be mapped back to a cell.
+func gridPathInterpolate(start, end Cell, distance int, out []Cell, outOffset, outStep int) error {
+	startIjk, startErr := start.cellToLocalIjk(start)
+	endIjk, endErr := start.cellToLocalIjk(end)
+
+	// start-to-start always succeeds; end-to-start can fail when this is the
+	// reverse attempt across pentagon distortion.
+	if err := cmp.Or(startErr, endErr); err != nil {
+		return err
+	}
+
+	startIjk.toCube()
+	endIjk.toCube()
+
+	invDistance := 1.0 / float64(distance)
+	iStep := float64(endIjk.i-startIjk.i) * invDistance
+	jStep := float64(endIjk.j-startIjk.j) * invDistance
+	kStep := float64(endIjk.k-startIjk.k) * invDistance
+
+	for n := 0; n <= distance; n++ {
+		current := cubeRound(
+			float64(startIjk.i)+iStep*float64(n),
+			float64(startIjk.j)+jStep*float64(n),
+			float64(startIjk.k)+kStep*float64(n),
+		)
+		current.fromCube()
+
+		cell, err := start.localIjkToCell(current)
+		if err != nil {
+			return err
+		}
+
+		out[outOffset+outStep*n] = cell
+	}
+
+	return nil
+}

--- a/x/h3go/localij_test.go
+++ b/x/h3go/localij_test.go
@@ -1,0 +1,531 @@
+/*
+ * Copyright 2026 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package h3go
+
+import (
+	"errors"
+	"testing"
+)
+
+// localIJPairs returns origin/target pairs from the shared grid corpus: each
+// cell paired with the cells in its grid disk, where local IJ is defined.
+func localIJPairs(t *testing.T) [][2]Cell {
+	t.Helper()
+
+	var pairs [][2]Cell
+
+	for _, origin := range gridCorpus(t) {
+		disk, err := origin.GridDisk(2)
+		if err != nil {
+			continue
+		}
+
+		for _, target := range disk {
+			pairs = append(pairs, [2]Cell{origin, target})
+		}
+	}
+
+	return pairs
+}
+
+// TestLocalIJRoundTrip checks that CellToLocalIJ followed by LocalIJToCell
+// recovers the original cell across the corpus, exercising the hexagon and
+// pentagon unfolding paths in both directions.
+func TestLocalIJRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for _, pair := range localIJPairs(t) {
+		origin, target := pair[0], pair[1]
+
+		ij, err := CellToLocalIJ(origin, target)
+		if err != nil {
+			continue
+		}
+
+		back, err := LocalIJToCell(origin, ij)
+		if err != nil {
+			t.Fatalf("LocalIJToCell(%015x, %v): %v", uint64(origin), ij, err)
+		}
+
+		if back != target {
+			t.Fatalf("round trip (%015x, %015x): got %015x via %v", uint64(origin), uint64(target), uint64(back), ij)
+		}
+	}
+}
+
+// TestCellToLocalIJErrors covers the input-validation and unfolding failure
+// paths of CellToLocalIJ.
+func TestCellToLocalIJErrors(t *testing.T) {
+	t.Parallel()
+
+	origin := CellFromString("8928308280fffff")
+
+	parent, err := origin.ImmediateParent()
+	if err != nil {
+		t.Fatalf("ImmediateParent: %v", err)
+	}
+
+	if _, err := CellToLocalIJ(origin, parent); !errors.Is(err, ErrResolutionMismatch) {
+		t.Fatalf("CellToLocalIJ(res mismatch): got %v, want ErrResolutionMismatch", err)
+	}
+
+	// Base cells far apart cannot be unfolded into a common coordinate space.
+	far := CellFromString("85283473fffffff")
+	farSibling := CellFromString("85f29263fffffff")
+
+	if _, err := CellToLocalIJ(far, farSibling); !errors.Is(err, ErrFailed) {
+		t.Fatalf("CellToLocalIJ(non-neighbor base cells): got %v, want ErrFailed", err)
+	}
+
+	bad := Cell(h3Init) | Cell(cellMode)<<modeOffset | Cell(numBaseCells)<<baseCellOffset
+	if _, err := CellToLocalIJ(bad, bad); !errors.Is(err, ErrCellInvalid) {
+		t.Fatalf("CellToLocalIJ(bad base cell): got %v, want ErrCellInvalid", err)
+	}
+
+	if _, err := CellToLocalIJ(origin, origin.setBaseCell(numBaseCells)); !errors.Is(err, ErrCellInvalid) {
+		t.Fatalf("CellToLocalIJ(bad target base cell): got %v, want ErrCellInvalid", err)
+	}
+}
+
+// TestLocalIJToCellErrors covers the failure paths of LocalIJToCell: an
+// out-of-range coordinate and an invalid origin base cell.
+func TestLocalIJToCellErrors(t *testing.T) {
+	t.Parallel()
+
+	origin := CellFromString("8928308280fffff")
+
+	if _, err := LocalIJToCell(origin, CoordIJ{I: 1 << 20, J: -(1 << 20)}); err == nil {
+		t.Fatal("LocalIJToCell(out of range): got nil error, want failure")
+	}
+
+	bad := Cell(h3Init) | Cell(cellMode)<<modeOffset | Cell(numBaseCells)<<baseCellOffset
+	if _, err := LocalIJToCell(bad, CoordIJ{I: 0, J: 0}); !errors.Is(err, ErrCellInvalid) {
+		t.Fatalf("LocalIJToCell(bad origin): got %v, want ErrCellInvalid", err)
+	}
+}
+
+// TestLocalIJRes0 covers the resolution-0 base-cell path of LocalIJToCell,
+// including moving off a base cell to a neighbor and an invalid move.
+func TestLocalIJRes0(t *testing.T) {
+	t.Parallel()
+
+	res0, err := Res0Cells()
+	if err != nil {
+		t.Fatalf("Res0Cells: %v", err)
+	}
+
+	for _, origin := range res0 {
+		ij, err := CellToLocalIJ(origin, origin)
+		if err != nil {
+			t.Fatalf("CellToLocalIJ(%015x, self): %v", uint64(origin), err)
+		}
+
+		back, err := LocalIJToCell(origin, ij)
+		if err != nil {
+			t.Fatalf("LocalIJToCell(%015x, %v): %v", uint64(origin), ij, err)
+		}
+
+		if back != origin {
+			t.Fatalf("res0 self round trip (%015x): got %015x", uint64(origin), uint64(back))
+		}
+	}
+}
+
+// TestGridDistance checks grid distance: zero to self, symmetry, and agreement
+// with the ring a cell lies on, across the corpus.
+func TestGridDistance(t *testing.T) {
+	t.Parallel()
+
+	for _, origin := range gridCorpus(t) {
+		if got, err := origin.GridDistance(origin); err != nil || got != 0 {
+			t.Fatalf("GridDistance(self) for %015x: got %d, %v, want 0, nil", uint64(origin), got, err)
+		}
+
+		rings, err := origin.GridDiskDistances(2)
+		if err != nil {
+			t.Fatalf("GridDiskDistances(%015x): %v", uint64(origin), err)
+		}
+
+		for distance, ring := range rings {
+			for _, target := range ring {
+				got, err := GridDistance(origin, target)
+				if err != nil {
+					continue
+				}
+
+				if got != distance {
+					t.Fatalf("GridDistance(%015x, %015x): got %d, want %d", uint64(origin), uint64(target), got, distance)
+				}
+
+				if rev, err := target.GridDistance(origin); err == nil && rev != got {
+					t.Fatalf("GridDistance not symmetric: %d vs %d", got, rev)
+				}
+			}
+		}
+	}
+}
+
+// TestGridPath checks the line of cells: correct length, endpoints, and that
+// consecutive cells are neighbors, across the corpus.
+func TestGridPath(t *testing.T) {
+	t.Parallel()
+
+	for _, pair := range localIJPairs(t) {
+		origin, target := pair[0], pair[1]
+
+		distance, err := origin.GridDistance(target)
+		if err != nil {
+			continue
+		}
+
+		path, err := GridPath(origin, target)
+		if err != nil {
+			continue
+		}
+
+		if len(path) != distance+1 {
+			t.Fatalf("GridPath(%015x, %015x): len %d, want %d", uint64(origin), uint64(target), len(path), distance+1)
+		}
+
+		if path[0] != origin || path[len(path)-1] != target {
+			t.Fatalf("GridPath(%015x, %015x): endpoints %015x..%015x", uint64(origin), uint64(target), uint64(path[0]), uint64(path[len(path)-1]))
+		}
+
+		for i := 1; i < len(path); i++ {
+			neighbor, err := path[i-1].IsNeighbor(path[i])
+			if err != nil {
+				t.Fatalf("IsNeighbor(%015x, %015x): %v", uint64(path[i-1]), uint64(path[i]), err)
+			}
+
+			if !neighbor {
+				t.Fatalf("GridPath(%015x, %015x): step %d not adjacent", uint64(origin), uint64(target), i)
+			}
+		}
+	}
+}
+
+// TestGridPathSelf covers the zero-distance short circuit of GridPath.
+func TestGridPathSelf(t *testing.T) {
+	t.Parallel()
+
+	origin := CellFromString("8928308280fffff")
+
+	path, err := origin.GridPath(origin)
+	if err != nil {
+		t.Fatalf("GridPath(self): %v", err)
+	}
+
+	if len(path) != 1 || path[0] != origin {
+		t.Fatalf("GridPath(self): got %v, want [origin]", path)
+	}
+}
+
+// TestGridMetricsErrorsPropagate checks that GridDistance and GridPath surface
+// the failure when the two cells cannot share a local coordinate space.
+func TestGridMetricsErrorsPropagate(t *testing.T) {
+	t.Parallel()
+
+	far := CellFromString("85283473fffffff")
+	farSibling := CellFromString("85f29263fffffff")
+
+	if _, err := GridDistance(far, farSibling); err == nil {
+		t.Fatal("GridDistance(far): got nil error, want failure")
+	}
+
+	if _, err := GridPath(far, farSibling); err == nil {
+		t.Fatal("GridPath(far): got nil error, want failure")
+	}
+
+	bad := Cell(h3Init) | Cell(cellMode)<<modeOffset | Cell(numBaseCells)<<baseCellOffset
+	if _, err := GridDistance(bad, bad); !errors.Is(err, ErrCellInvalid) {
+		t.Fatalf("GridDistance(bad): got %v, want ErrCellInvalid", err)
+	}
+}
+
+// TestLocalIJPentagonUnfold exercises the pentagon unfolding paths in both
+// directions: each pentagon paired with the cells around it as both origin and
+// target. Reachable pairs round trip; unreachable ones (across pentagon
+// distortion) return an error, exercising the unfold failure branches.
+func TestLocalIJPentagonUnfold(t *testing.T) {
+	t.Parallel()
+
+	for _, res := range []int{1, 2, 3} {
+		pents, err := Pentagons(res)
+		if err != nil {
+			t.Fatalf("Pentagons(%d): %v", res, err)
+		}
+
+		for _, pentagon := range pents {
+			neighborhood, err := pentagon.GridDisk(4)
+			if err != nil {
+				t.Fatalf("GridDisk(%015x): %v", uint64(pentagon), err)
+			}
+
+			for _, cell := range neighborhood {
+				assertLocalIJRoundTrip(t, pentagon, cell)
+				assertLocalIJRoundTrip(t, cell, pentagon)
+			}
+		}
+	}
+}
+
+// assertLocalIJRoundTrip checks that, when CellToLocalIJ succeeds, LocalIJToCell
+// recovers the target. Failures are allowed (pentagon distortion) and skipped.
+func assertLocalIJRoundTrip(t *testing.T, origin, target Cell) {
+	t.Helper()
+
+	ij, err := CellToLocalIJ(origin, target)
+	if err != nil {
+		return
+	}
+
+	back, err := LocalIJToCell(origin, ij)
+	if err != nil {
+		return
+	}
+
+	if back != target {
+		t.Fatalf("round trip (%015x, %015x): got %015x via %v", uint64(origin), uint64(target), uint64(back), ij)
+	}
+}
+
+// TestLocalIJRes0Errors covers the resolution-0 failure paths of LocalIJToCell:
+// an out-of-range coordinate and a move off a pentagon in the deleted direction.
+func TestLocalIJRes0Errors(t *testing.T) {
+	t.Parallel()
+
+	res0, err := Res0Cells()
+	if err != nil {
+		t.Fatalf("Res0Cells: %v", err)
+	}
+
+	if _, err := LocalIJToCell(res0[0], CoordIJ{I: 5, J: 5}); !errors.Is(err, ErrFailed) {
+		t.Fatalf("LocalIJToCell(res0, out of range): got %v, want ErrFailed", err)
+	}
+
+	pents, err := Pentagons(0)
+	if err != nil {
+		t.Fatalf("Pentagons(0): %v", err)
+	}
+
+	// The k-axis direction is deleted at a pentagon; {I:-1,J:-1} maps to it.
+	if _, err := LocalIJToCell(pents[0], CoordIJ{I: -1, J: -1}); !errors.Is(err, ErrFailed) {
+		t.Fatalf("LocalIJToCell(res0 pentagon, deleted dir): got %v, want ErrFailed", err)
+	}
+}
+
+// TestGridPathLongLine exercises a longer interpolated line, reaching the
+// rounding cases of the cube-coordinate path construction.
+func TestGridPathLongLine(t *testing.T) {
+	t.Parallel()
+
+	origin := CellFromString("8928308280fffff")
+
+	rings, err := origin.GridDiskDistances(6)
+	if err != nil {
+		t.Fatalf("GridDiskDistances: %v", err)
+	}
+
+	for _, target := range rings[6] {
+		path, err := GridPath(origin, target)
+		if err != nil {
+			continue
+		}
+
+		if len(path) != 7 {
+			t.Fatalf("GridPath(%015x, %015x): len %d, want 7", uint64(origin), uint64(target), len(path))
+		}
+	}
+}
+
+// res2Cell builds a resolution-2 cell with the given base cell and center digits.
+func res2Cell(baseCell int) Cell {
+	cell := Cell(h3Init) | Cell(cellMode)<<modeOffset
+	cell = cell.setResolution(2).setBaseCell(baseCell)
+	cell = cell.setIndexDigit(1, centerDigit).setIndexDigit(2, centerDigit)
+
+	return cell
+}
+
+// TestLocalIJDefensive covers the invalid-input branches of the local IJ
+// conversions that a validly constructed cell cannot reach, using malformed
+// pentagon indexes whose corrupt leading digit drives the failure paths.
+func TestLocalIJDefensive(t *testing.T) {
+	t.Parallel()
+
+	pent, err := Pentagons(2)
+	if err != nil {
+		t.Fatalf("Pentagons(2): %v", err)
+	}
+
+	pentagon := pent[0]
+	baseCell := pentagon.BaseCellNumber()
+
+	neighborBC := invalidBaseCell
+
+	for dir := 1; dir < numDigits; dir++ {
+		candidate := baseCellNeighbors[baseCell][dir]
+		if candidate != invalidBaseCell && candidate != baseCell {
+			neighborBC = candidate
+			break
+		}
+	}
+
+	neighbor := res2Cell(neighborBC)
+
+	// A pentagon index whose leading digit is the unused sentinel.
+	corruptLead := pentagon.setIndexDigit(1, invalidDigit)
+	// A pentagon index whose leading digit is the deleted k axis.
+	corruptK := pentagon.setIndexDigit(1, kAxesDigit)
+
+	// cellToLocalIjk: invalid leading digit on the pentagon origin / index.
+	if _, err := corruptLead.cellToLocalIjk(neighbor); !errors.Is(err, ErrCellInvalid) {
+		t.Fatalf("cellToLocalIjk(corrupt origin): got %v, want ErrCellInvalid", err)
+	}
+
+	if _, err := neighbor.cellToLocalIjk(corruptLead); !errors.Is(err, ErrCellInvalid) {
+		t.Fatalf("cellToLocalIjk(corrupt index): got %v, want ErrCellInvalid", err)
+	}
+
+	if _, err := corruptLead.cellToLocalIjk(pentagon); !errors.Is(err, ErrCellInvalid) {
+		t.Fatalf("cellToLocalIjk(corrupt same pentagon): got %v, want ErrCellInvalid", err)
+	}
+
+	// cellToLocalIjk: a k-axis leading digit selects a -1 rotation entry.
+	if _, err := corruptK.cellToLocalIjk(neighbor); !errors.Is(err, ErrCellInvalid) {
+		t.Fatalf("cellToLocalIjk(k-axis origin): got %v, want ErrCellInvalid", err)
+	}
+
+	// localIjkToCell via LocalIJToCell, using coordinates that map to a neighbor
+	// (dir != center) and to the origin itself (dir == center).
+	disk, err := pentagon.GridDisk(1)
+	if err != nil {
+		t.Fatalf("GridDisk: %v", err)
+	}
+
+	var neighborCell Cell
+
+	for _, cell := range disk {
+		if cell != pentagon {
+			neighborCell = cell
+			break
+		}
+	}
+
+	neighborIJ, err := CellToLocalIJ(pentagon, neighborCell)
+	if err != nil {
+		t.Fatalf("CellToLocalIJ(neighbor): %v", err)
+	}
+
+	selfIJ, err := CellToLocalIJ(pentagon, pentagon)
+	if err != nil {
+		t.Fatalf("CellToLocalIJ(self): %v", err)
+	}
+
+	if _, err := LocalIJToCell(corruptLead, neighborIJ); !errors.Is(err, ErrCellInvalid) {
+		t.Fatalf("LocalIJToCell(corrupt origin, neighbor): got %v, want ErrCellInvalid", err)
+	}
+
+	if _, err := LocalIJToCell(corruptLead, selfIJ); !errors.Is(err, ErrCellInvalid) {
+		t.Fatalf("LocalIJToCell(corrupt origin, self): got %v, want ErrCellInvalid", err)
+	}
+
+	if _, err := LocalIJToCell(corruptK, neighborIJ); !errors.Is(err, ErrCellInvalid) {
+		t.Fatalf("LocalIJToCell(k-axis origin, neighbor): got %v, want ErrCellInvalid", err)
+	}
+
+	if _, err := LocalIJToCell(corruptK, selfIJ); !errors.Is(err, ErrCellInvalid) {
+		t.Fatalf("LocalIJToCell(k-axis origin, self): got %v, want ErrCellInvalid", err)
+	}
+
+	// A coordinate that resolves to a different base cell (dir != center at the
+	// base-cell level) drives the localIjkToCell pentagon-origin branches that a
+	// same-base-cell neighbor cannot reach. Such a cell is several rings out.
+	disk4, err := pentagon.GridDisk(4)
+	if err != nil {
+		t.Fatalf("GridDisk(4): %v", err)
+	}
+
+	var crossCell Cell
+
+	for _, cell := range disk4 {
+		if cell.BaseCellNumber() != baseCell {
+			crossCell = cell
+			break
+		}
+	}
+
+	crossIJ, err := CellToLocalIJ(pentagon, crossCell)
+	if err != nil {
+		t.Fatalf("CellToLocalIJ(cross): %v", err)
+	}
+
+	if _, err := LocalIJToCell(corruptLead, crossIJ); !errors.Is(err, ErrCellInvalid) {
+		t.Fatalf("LocalIJToCell(corrupt origin, cross): got %v, want ErrCellInvalid", err)
+	}
+
+	if _, err := LocalIJToCell(corruptK, crossIJ); !errors.Is(err, ErrCellInvalid) {
+		t.Fatalf("LocalIJToCell(k-axis origin, cross): got %v, want ErrCellInvalid", err)
+	}
+
+	// A coordinate pointing in the deleted k direction is undefined at a pentagon.
+	kOffset := coordIJK{}.neighbor(kAxesDigit)
+
+	for r := pentagon.Resolution() - 1; r >= 0; r-- {
+		if isResClassIII(r + 1) {
+			kOffset.downAp7()
+		} else {
+			kOffset.downAp7r()
+		}
+	}
+
+	if _, err := pentagon.localIjkToCell(kOffset); !errors.Is(err, ErrPentagon) {
+		t.Fatalf("localIjkToCell(k direction): got %v, want ErrPentagon", err)
+	}
+}
+
+// TestCellToLocalIJPentagonUnfoldFails covers the index-on-pentagon failed
+// unfold branch: a hexagon origin and an index in a neighboring pentagon base
+// cell whose relative direction cannot be unfolded across an icosahedron face.
+func TestCellToLocalIJPentagonUnfoldFails(t *testing.T) {
+	t.Parallel()
+
+	origin := CellFromString("81003ffffffffff")
+	index := CellFromString("8108bffffffffff")
+
+	if _, err := CellToLocalIJ(origin, index); !errors.Is(err, ErrFailed) {
+		t.Fatalf("CellToLocalIJ(hex, pentagon-base-cell across faces): got %v, want ErrFailed", err)
+	}
+}
+
+// TestGridPathInterpolateError covers the self-conversion error path of the
+// interpolation helper, reached when its anchor origin is itself invalid.
+func TestGridPathInterpolateError(t *testing.T) {
+	t.Parallel()
+
+	pent, err := Pentagons(2)
+	if err != nil {
+		t.Fatalf("Pentagons(2): %v", err)
+	}
+
+	corrupt := pent[0].setIndexDigit(1, invalidDigit)
+	out := make([]Cell, 2)
+
+	if err := gridPathInterpolate(corrupt, pent[0], 1, out, 0, 1); !errors.Is(err, ErrCellInvalid) {
+		t.Fatalf("gridPathInterpolate(corrupt anchor): got %v, want ErrCellInvalid", err)
+	}
+}

--- a/x/h3go/paritytest/localij_test.go
+++ b/x/h3go/paritytest/localij_test.go
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2026 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package paritytest
+
+import (
+	"testing"
+
+	"github.com/uber/h3-go/v4"
+	"github.com/uber/h3-go/v4/x/h3go"
+)
+
+// localIJPairs returns origin/target cell pairs drawn from the shared corpus:
+// each corpus cell paired with the cells in its grid disk, which is where local
+// IJ coordinates are defined.
+func localIJPairs(t *testing.T) [][2]h3.Cell {
+	t.Helper()
+
+	var pairs [][2]h3.Cell
+
+	for _, origin := range referenceCorpus(t) {
+		disk, err := h3.GridDisk(origin, 3)
+		if err != nil {
+			continue
+		}
+
+		for _, target := range disk {
+			if target == 0 {
+				continue
+			}
+
+			pairs = append(pairs, [2]h3.Cell{origin, target})
+		}
+	}
+
+	return pairs
+}
+
+// TestCellToLocalIJMatchesCgo asserts that local IJ coordinates and their
+// round trip match the cgo reference for origin/target pairs across the corpus,
+// including error parity.
+func TestCellToLocalIJMatchesCgo(t *testing.T) {
+	t.Parallel()
+
+	for _, pair := range localIJPairs(t) {
+		origin, target := pair[0], pair[1]
+
+		want, wantErr := h3.CellToLocalIJ(origin, target)
+		got, gotErr := h3go.CellToLocalIJ(h3goCell(origin), h3goCell(target))
+
+		if !bothErr(wantErr, gotErr) {
+			t.Fatalf("CellToLocalIJ(%015x, %015x) error mismatch: cgo=%v h3go=%v", uint64(origin), uint64(target), wantErr, gotErr)
+		}
+
+		if wantErr != nil {
+			continue
+		}
+
+		if got.I != want.I || got.J != want.J {
+			t.Fatalf("CellToLocalIJ(%015x, %015x): got {%d,%d}, want {%d,%d}", uint64(origin), uint64(target), got.I, got.J, want.I, want.J)
+		}
+
+		// Round trip back to the cell.
+		back, err := h3go.LocalIJToCell(h3goCell(origin), h3go.CoordIJ{I: got.I, J: got.J})
+		if err != nil {
+			t.Fatalf("LocalIJToCell(%015x, %v): %v", uint64(origin), got, err)
+		}
+
+		if back != h3goCell(target) {
+			t.Fatalf("round trip (%015x, %015x): got %015x", uint64(origin), uint64(target), uint64(back))
+		}
+	}
+}
+
+// TestLocalIJToCellMatchesCgo asserts LocalIJToCell matches the cgo reference,
+// including error parity, by feeding back coordinates obtained from the cgo
+// CellToLocalIJ plus some out-of-range offsets.
+func TestLocalIJToCellMatchesCgo(t *testing.T) {
+	t.Parallel()
+
+	for _, pair := range localIJPairs(t) {
+		origin, target := pair[0], pair[1]
+
+		ij, err := h3.CellToLocalIJ(origin, target)
+		if err != nil {
+			continue
+		}
+
+		for _, delta := range []h3.CoordIJ{{I: 0, J: 0}, {I: 2, J: 0}, {I: 0, J: -2}, {I: 5, J: 5}} {
+			coord := h3.CoordIJ{I: ij.I + delta.I, J: ij.J + delta.J}
+
+			want, wantErr := h3.LocalIJToCell(origin, coord)
+			got, gotErr := h3go.LocalIJToCell(h3goCell(origin), h3go.CoordIJ{I: coord.I, J: coord.J})
+
+			if !bothErr(wantErr, gotErr) {
+				t.Fatalf("LocalIJToCell(%015x, %v) error mismatch: cgo=%v h3go=%v", uint64(origin), coord, wantErr, gotErr)
+			}
+
+			if wantErr == nil && got != h3goCell(want) {
+				t.Fatalf("LocalIJToCell(%015x, %v): got %015x, want %015x", uint64(origin), coord, uint64(got), uint64(want))
+			}
+		}
+	}
+}
+
+// TestGridDistanceMatchesCgo asserts grid distance matches the cgo reference for
+// origin/target pairs, including error parity.
+func TestGridDistanceMatchesCgo(t *testing.T) {
+	t.Parallel()
+
+	for _, pair := range localIJPairs(t) {
+		origin, target := pair[0], pair[1]
+
+		want, wantErr := h3.GridDistance(origin, target)
+		got, gotErr := h3go.GridDistance(h3goCell(origin), h3goCell(target))
+
+		if !bothErr(wantErr, gotErr) {
+			t.Fatalf("GridDistance(%015x, %015x) error mismatch: cgo=%v h3go=%v", uint64(origin), uint64(target), wantErr, gotErr)
+		}
+
+		if wantErr == nil && got != want {
+			t.Fatalf("GridDistance(%015x, %015x): got %d, want %d", uint64(origin), uint64(target), got, want)
+		}
+	}
+}
+
+// TestGridPathMatchesCgo asserts the grid path matches the cgo reference cell for
+// cell, including error parity.
+func TestGridPathMatchesCgo(t *testing.T) {
+	t.Parallel()
+
+	for _, pair := range localIJPairs(t) {
+		origin, target := pair[0], pair[1]
+
+		want, wantErr := h3.GridPath(origin, target)
+		got, gotErr := h3go.GridPath(h3goCell(origin), h3goCell(target))
+
+		if !bothErr(wantErr, gotErr) {
+			t.Fatalf("GridPath(%015x, %015x) error mismatch: cgo=%v h3go=%v", uint64(origin), uint64(target), wantErr, gotErr)
+		}
+
+		if wantErr != nil {
+			continue
+		}
+
+		if len(got) != len(want) {
+			t.Fatalf("GridPath(%015x, %015x): len got=%d want=%d", uint64(origin), uint64(target), len(got), len(want))
+		}
+
+		for i := range want {
+			if got[i] != h3goCell(want[i]) {
+				t.Fatalf("GridPath(%015x, %015x)[%d]: got %015x, want %015x", uint64(origin), uint64(target), i, uint64(got[i]), uint64(want[i]))
+			}
+		}
+	}
+}


### PR DESCRIPTION
Add CellToLocalIJ/LocalIJToCell, GridDistance, GridPath (and Cell method forms) plus the CoordIJ type, implementing the local IJK/IJ coordinate machinery, cube-coordinate line interpolation, and the pentagon rotation tables. Verified against the cgo reference over the shared corpus with full in-package coverage.