### PR TITLE
test+perf: parity benchmarks and allocation cuts for x/h3go

### DIFF
--- a/x/h3go/faceijk.go
+++ b/x/h3go/faceijk.go
@@ -478,9 +478,14 @@ func (v vec2d) toVec3(face, res int, substrate bool) vec3d {
 	}
 
 	if substrate {
-		// Callers only project substrate grids at Class II (even) resolutions,
-		// so no Class III substrate adjustment is needed here.
 		r *= mOneThird
+		// Substrate grids at a Class III resolution carry an extra aperture-7
+		// step; H3's own vertex builders bump res to Class II before reaching
+		// here, so this only matters for a hand-built odd-res substrate grid,
+		// but it mirrors the C reference exactly.
+		if isResClassIII(res) {
+			r *= mRSqrt7
+		}
 	}
 
 	r *= res0UGnomonic

--- a/x/h3go/grid.go
+++ b/x/h3go/grid.go
@@ -248,21 +248,107 @@ func (c Cell) neighborRotations(dir, rotations int) (Cell, int, error) {
 	return current, rotations, nil
 }
 
+// maxGridDiskSize returns the maximum number of cells in a grid disk of radius
+// k: the origin plus six cells per ring. It sizes the output buffer up front so
+// the traversal never has to grow it.
+func maxGridDiskSize(k int) int {
+	return 3*k*(k+1) + 1
+}
+
+// ringSize returns the number of cells in the hollow ring at grid distance d: 1
+// at the origin, 6*d otherwise.
+func ringSize(d int) int {
+	if d == 0 {
+		return 1
+	}
+
+	return 6 * d
+}
+
+// gridDiskUnsafeInto appends the grid disk of radius k around c to dst, the
+// origin first and then each ring outward, using the fast spiral traversal. It
+// fails with ErrPentagon on pentagon distortion, having appended a partial
+// result the caller is expected to discard. The caller sizes dst's capacity.
+func (c Cell) gridDiskUnsafeInto(k int, dst []Cell) ([]Cell, error) {
+	if k < 0 {
+		return dst, ErrDomain
+	}
+
+	cursor := c
+	dst = append(dst, cursor)
+
+	if cursor.IsPentagon() {
+		return dst, ErrPentagon
+	}
+
+	rotations := 0
+	for ring := 1; ring <= k; ring++ {
+		// Step outward to the start of the next ring before tracing it.
+		next, rot, err := cursor.neighborRotations(nextRingDirection, rotations)
+		if err != nil {
+			return dst, err
+		}
+
+		cursor, rotations = next, rot
+		if cursor.IsPentagon() {
+			return dst, ErrPentagon
+		}
+
+		for direction := 0; direction < 6; direction++ {
+			for i := 0; i < ring; i++ {
+				next, rot, err := cursor.neighborRotations(directions[direction], rotations)
+				if err != nil {
+					return dst, err
+				}
+
+				cursor, rotations = next, rot
+				dst = append(dst, cursor)
+
+				if cursor.IsPentagon() {
+					return dst, ErrPentagon
+				}
+			}
+		}
+	}
+
+	return dst, nil
+}
+
+// gridDiskInto appends the grid disk of radius k around c to dst, trying the
+// fast spiral first and falling back to the safe breadth-first traversal on
+// pentagon distortion. The caller sizes dst's capacity.
+func (c Cell) gridDiskInto(k int, dst []Cell) ([]Cell, error) {
+	start := len(dst)
+
+	dst, err := c.gridDiskUnsafeInto(k, dst)
+	if err == nil {
+		return dst, nil
+	}
+
+	// Discard the partial spiral and refill from the safe traversal.
+	dst = dst[:start]
+
+	rings, err := c.GridDiskDistancesSafe(k)
+	if err != nil {
+		return dst, err
+	}
+
+	for _, ring := range rings {
+		dst = append(dst, ring...)
+	}
+
+	return dst, nil
+}
+
 // GridDisk returns the cells within grid distance k of the origin cell. The
 // origin is included. Output ordering is not significant. It falls back to the
 // safe traversal when the fast one meets pentagon distortion.
 func (c Cell) GridDisk(k int) ([]Cell, error) {
-	rings, err := c.GridDiskDistances(k)
-	if err != nil {
-		return nil, err
+	if k < 0 {
+		return nil, ErrDomain
 	}
 
-	var out []Cell
-	for _, ring := range rings {
-		out = append(out, ring...)
-	}
-
-	return out, nil
+	return c.gridDiskInto(k, make([]Cell, 0, maxGridDiskSize(k)))
 }
 
 // GridDisk returns the cells within grid distance k of the origin cell.
@@ -272,25 +358,32 @@ func GridDisk(origin Cell, k int) ([]Cell, error) {
 
 // GridDisksUnsafe returns, for each origin, the cells within grid distance k of
 // that origin. The outer slice matches the order of origins; inner ordering is
-// not significant. It fails if any disk encounters pentagon distortion.
+// not significant. It fails if any disk encounters pentagon distortion. Every
+// disk shares one backing buffer sized for the worst case, so the result costs
+// two allocations regardless of the number of origins.
 func GridDisksUnsafe(origins []Cell, k int) ([][]Cell, error) {
 	if len(origins) == 0 {
 		return nil, nil
 	}
 
+	if k < 0 {
+		return nil, ErrDomain
+	}
+
 	out := make([][]Cell, len(origins))
+	buf := make([]Cell, 0, len(origins)*maxGridDiskSize(k))
+
 	for i, origin := range origins {
-		rings, err := origin.GridDiskDistancesUnsafe(k)
+		start := len(buf)
+
+		var err error
+
+		buf, err = origin.gridDiskUnsafeInto(k, buf)
 		if err != nil {
 			return nil, err
 		}
 
-		var flat []Cell
-		for _, ring := range rings {
-			flat = append(flat, ring...)
-		}
-
-		out[i] = flat
+		out[i] = buf[start:len(buf):len(buf)]
 	}
 
 	return out, nil
@@ -323,55 +416,21 @@ func (c Cell) GridDiskDistancesUnsafe(k int) ([][]Cell, error) {
 		return nil, ErrDomain
 	}
 
-	rings := make([][]Cell, k+1)
-
-	cursor := c
-	rings[0] = append(rings[0], cursor)
-
-	if cursor.IsPentagon() {
-		return nil, ErrPentagon
+	buf, err := c.gridDiskUnsafeInto(k, make([]Cell, 0, maxGridDiskSize(k)))
+	if err != nil {
+		return nil, err
 	}
 
-	ring := 1
-	direction := 0
-	i := 0
-	rotations := 0
+	// The spiral fills buf ring by ring, so each ring is a contiguous window
+	// into the one backing array.
+	rings := make([][]Cell, k+1)
 
-	for ring <= k {
-		if direction == 0 && i == 0 {
-			next, rot, err := cursor.neighborRotations(nextRingDirection, rotations)
-			if err != nil {
-				return nil, err
-			}
+	offset := 0
 
-			cursor, rotations = next, rot
-			if cursor.IsPentagon() {
-				return nil, ErrPentagon
-			}
-		}
-
-		next, rot, err := cursor.neighborRotations(directions[direction], rotations)
-		if err != nil {
-			return nil, err
-		}
-
-		cursor, rotations = next, rot
-		rings[ring] = append(rings[ring], cursor)
-
-		i++
-		if i == ring {
-			i = 0
-			direction++
-
-			if direction == 6 {
-				direction = 0
-				ring++
-			}
-		}
-
-		if cursor.IsPentagon() {
-			return nil, ErrPentagon
-		}
+	for d := 0; d <= k; d++ {
+		size := ringSize(d)
+		rings[d] = buf[offset : offset+size : offset+size]
+		offset += size
 	}
 
 	return rings, nil
@@ -392,6 +451,19 @@ func (c Cell) GridDiskDistancesSafe(k int) ([][]Cell, error) {
 	}
 
 	rings := make([][]Cell, k+1)
+
+	// Give every ring an exact-capacity window into one shared buffer so the
+	// breadth-first appends below never reallocate.
+	buf := make([]Cell, maxGridDiskSize(k))
+
+	offset := 0
+
+	for d := 0; d <= k; d++ {
+		size := ringSize(d)
+		rings[d] = buf[offset : offset : offset+size]
+		offset += size
+	}
+
 	seen := map[Cell]int{c: 0}
 	rings[0] = append(rings[0], c)
 
@@ -473,7 +545,8 @@ func (c Cell) GridRingUnsafe(k int) ([]Cell, error) {
 	}
 
 	lastIndex := cursor
-	out := []Cell{cursor}
+	out := make([]Cell, 0, ringSize(k))
+	out = append(out, cursor)
 
 	for direction := 0; direction < 6; direction++ {
 		for pos := 0; pos < k; pos++ {

--- a/x/h3go/hierarchy.go
+++ b/x/h3go/hierarchy.go
@@ -16,7 +16,10 @@
 
 package h3go
 
-import "iter"
+import (
+	"iter"
+	"slices"
+)
 
 // Child-set sizes: a hexagon has 7 immediate children, a pentagon 6 (its
 // K-axis child is deleted).
@@ -347,8 +350,11 @@ func UncompactCells(in []Cell, res int) ([]Cell, error) {
 	return out, nil
 }
 
-// CompactCells merges full sets of children into their parent recursively,
-// until no more merges are possible. The output order is unspecified.
+// CompactCells merges full sets of children into their parent, repeating up the
+// hierarchy until no more merges are possible. It assumes the input cells share
+// one resolution (the documented contract): sorting then groups every parent's
+// children into one contiguous run, so a single linear scan per level decides
+// which runs are complete. The output order is unspecified.
 func CompactCells(in []Cell) ([]Cell, error) {
 	if len(in) == 0 {
 		return []Cell{}, nil
@@ -361,64 +367,86 @@ func CompactCells(in []Cell) ([]Cell, error) {
 
 		return out, nil
 	}
-	remaining := make([]Cell, len(in))
-	copy(remaining, in)
+
+	remaining := slices.Clone(in)
+
 	var output []Cell
+
+	// next collects the parents promoted to the coarser level; it is rebuilt
+	// each pass and handed back as remaining.
+	var next []Cell
 
 	for len(remaining) > 0 {
 		parentRes := remaining[0].Resolution() - 1
 		if parentRes < 0 {
-			// Compacted all the way up to base cells.
+			// Compacted all the way up to the base cells.
 			output = append(output, remaining...)
 			break
 		}
-		counts := make(map[Cell]int)
 
-		order := make([]Cell, 0, len(remaining))
-		for _, c := range remaining {
-			if c == 0 {
+		// Sorting brings each parent's children together (siblings differ only
+		// in the lowest occupied digit) and pushes any zero padding to the front.
+		slices.Sort(remaining)
+
+		next = next[:0]
+
+		runStart := 0
+		for runStart < len(remaining) {
+			cell := remaining[runStart]
+			if cell == 0 {
+				// Skip zero padding; it never compacts.
+				runStart++
 				continue
 			}
 
-			if reservedBits(c) != 0 {
+			if reservedBits(cell) != 0 {
 				return nil, ErrCellInvalid
 			}
 
-			parent, err := c.Parent(parentRes)
+			parent, err := cell.Parent(parentRes)
 			if err != nil {
 				return nil, err
 			}
 
-			if _, ok := counts[parent]; !ok {
-				order = append(order, parent)
+			// Extend the run over every following cell with the same parent.
+			runEnd := runStart + 1
+			for runEnd < len(remaining) {
+				sibling := remaining[runEnd]
+				if reservedBits(sibling) != 0 {
+					return nil, ErrCellInvalid
+				}
+
+				siblingParent, err := sibling.Parent(parentRes)
+				if err != nil {
+					return nil, err
+				}
+
+				if siblingParent != parent {
+					break
+				}
+
+				runEnd++
 			}
 
-			counts[parent]++
-			if counts[parent] > parent.fullChildCount() {
+			fullCount := parent.fullChildCount()
+			runLen := runEnd - runStart
+
+			switch {
+			case runLen > fullCount:
+				// More children than a parent can hold: duplicate input.
 				return nil, ErrDuplicateInput
-			}
-		}
-		compactable := make(map[Cell]bool)
-		var next []Cell
-
-		for _, parent := range order {
-			if counts[parent] == parent.fullChildCount() {
-				compactable[parent] = true
+			case runLen == fullCount:
+				// A complete set: replace the children with the parent.
 				next = append(next, parent)
-			}
-		}
-
-		for _, c := range remaining {
-			if c == 0 {
-				continue
+			default:
+				// Incomplete: the children stay in the output unchanged.
+				output = append(output, remaining[runStart:runEnd]...)
 			}
 
-			parent, _ := c.Parent(parentRes)
-			if !compactable[parent] {
-				output = append(output, c)
-			}
+			runStart = runEnd
 		}
-		remaining = next
+
+		remaining = append(remaining[:0], next...)
 	}
 
 	return output, nil

--- a/x/h3go/multipoly.go
+++ b/x/h3go/multipoly.go
@@ -30,42 +30,43 @@ var (
 
 // arc is one directed edge of a cell during multipolygon assembly. Arcs form
 // doubly-linked loops (counter-clockwise) and a union-find forest whose roots
-// identify connected components (each component becomes one polygon).
+// identify connected components (each component becomes one polygon). Links are
+// indices into the arc slice rather than pointers, so the whole graph lives in
+// one allocation and survives the slice growing.
 type arc struct {
-	parent  *arc
-	prev    *arc
-	next    *arc
+	parent  int
+	prev    int
+	next    int
 	id      DirectedEdge
 	rank    int
 	removed bool
 	visited bool
 }
 
-// root returns the representative arc of the connected component, compressing
-// the path along the way.
-func (a *arc) root() *arc {
-	if a.parent == a {
-		return a
+// arcRoot returns the index of the representative arc of idx's connected
+// component, compressing the path along the way.
+func arcRoot(arcs []arc, idx int) int {
+	for arcs[idx].parent != idx {
+		arcs[idx].parent = arcs[arcs[idx].parent].parent
+		idx = arcs[idx].parent
 	}
 
-	a.parent = a.parent.root()
-
-	return a.parent
+	return idx
 }
 
-// union merges the connected components of two arcs, attaching the lower-rank
+// arcUnion merges the connected components of two arcs, attaching the lower-rank
 // root under the higher-rank one.
-func union(first, second *arc) {
-	first = first.root()
-	second = second.root()
+func arcUnion(arcs []arc, first, second int) {
+	first = arcRoot(arcs, first)
+	second = arcRoot(arcs, second)
 
-	if first.rank < second.rank {
+	if arcs[first].rank < arcs[second].rank {
 		first, second = second, first
 	}
 
 	if first != second {
-		first.rank += second.rank
-		second.parent = first
+		arcs[first].rank += arcs[second].rank
+		arcs[second].parent = first
 	}
 }
 
@@ -99,24 +100,21 @@ func validateCellSet(cells []Cell) error {
 
 // buildArcs creates the arcs for every cell, linking each cell's edges into a
 // counter-clockwise loop and indexing them by edge id for reverse lookup. Every
-// arc in a cell starts in the cell's own connected component.
-func buildArcs(cells []Cell) ([]*arc, map[DirectedEdge]*arc) {
-	var arcs []*arc
-
-	index := make(map[DirectedEdge]*arc)
+// arc in a cell starts in the cell's own connected component. All arcs share one
+// backing slice; links are indices into it.
+func buildArcs(cells []Cell) ([]arc, map[DirectedEdge]int) {
+	arcs := make([]arc, 0, len(cells)*numCellEdges)
+	index := make(map[DirectedEdge]int, len(cells)*numCellEdges)
 
 	for _, cell := range cells {
 		// cell is valid here, so enumerating its edges cannot fail.
 		edges, _ := cell.DirectedEdges()
 		count := len(edges)
+		base := len(arcs)
 
-		block := make([]*arc, count)
-		for i := range block {
-			block[i] = &arc{id: edges[i], rank: 1}
-		}
-
-		for i := range block {
-			block[i].parent = block[0]
+		for i := 0; i < count; i++ {
+			// Every arc in the cell starts rooted at the cell's first arc.
+			arcs = append(arcs, arc{id: edges[i], rank: 1, parent: base})
 		}
 
 		order := idxHex[:]
@@ -124,17 +122,16 @@ func buildArcs(cells []Cell) ([]*arc, map[DirectedEdge]*arc) {
 			order = idxPent[:]
 		}
 
-		for i := range block {
+		for i := 0; i < count; i++ {
 			cur := order[i]
 			prev := order[(i-1+count)%count]
 			next := order[(i+1)%count]
-			block[cur].prev = block[prev]
-			block[cur].next = block[next]
+			arcs[base+cur].prev = base + prev
+			arcs[base+cur].next = base + next
 		}
 
-		for i := range block {
-			arcs = append(arcs, block[i])
-			index[block[i].id] = block[i]
+		for i := 0; i < count; i++ {
+			index[arcs[base+i].id] = base + i
 		}
 	}
 
@@ -144,29 +141,29 @@ func buildArcs(cells []Cell) ([]*arc, map[DirectedEdge]*arc) {
 // cancelArcPairs removes each pair of opposite edges shared by two adjacent
 // cells, stitching the linked loops back together and merging the two arcs'
 // connected components. What remains are the outline loops of the cell set.
-func cancelArcPairs(arcs []*arc, index map[DirectedEdge]*arc) {
-	for _, current := range arcs {
-		if current.removed {
+func cancelArcPairs(arcs []arc, index map[DirectedEdge]int) {
+	for current := range arcs {
+		if arcs[current].removed {
 			continue
 		}
 
-		// current.id is a valid edge, so reversing it cannot fail.
-		reversed, _ := current.id.Reverse()
+		// arcs[current].id is a valid edge, so reversing it cannot fail.
+		reversed, _ := arcs[current].id.Reverse()
 
 		opposite, ok := index[reversed]
 		if !ok {
 			continue
 		}
 
-		current.removed = true
-		opposite.removed = true
+		arcs[current].removed = true
+		arcs[opposite].removed = true
 
-		current.next.prev = opposite.prev
-		current.prev.next = opposite.next
-		opposite.next.prev = current.prev
-		opposite.prev.next = current.next
+		arcs[arcs[current].next].prev = arcs[opposite].prev
+		arcs[arcs[current].prev].next = arcs[opposite].next
+		arcs[arcs[opposite].next].prev = arcs[current].prev
+		arcs[arcs[opposite].prev].next = arcs[current].next
 
-		union(current, opposite)
+		arcUnion(arcs, current, opposite)
 	}
 }
 
@@ -182,15 +179,15 @@ type outlineLoop struct {
 // loop's connected component and enclosed area. Loops are sorted by component,
 // then by area so that each polygon's loops are contiguous with its outer loop
 // (smallest enclosed area) first.
-func buildOutlineLoops(arcs []*arc) []outlineLoop {
-	for _, current := range arcs {
-		current.visited = false
+func buildOutlineLoops(arcs []arc) []outlineLoop {
+	for i := range arcs {
+		arcs[i].visited = false
 	}
 
 	var loops []outlineLoop
 
-	for _, start := range arcs {
-		if start.visited || start.removed {
+	for start := range arcs {
+		if arcs[start].visited || arcs[start].removed {
 			continue
 		}
 
@@ -198,19 +195,19 @@ func buildOutlineLoops(arcs []*arc) []outlineLoop {
 
 		current := start
 		for {
-			// current.id is valid, so its boundary cannot fail.
-			boundary, _ := current.id.Boundary()
+			// arcs[current].id is valid, so its boundary cannot fail.
+			boundary, _ := arcs[current].id.Boundary()
 			verts = append(verts, boundary[:len(boundary)-1]...)
-			current.visited = true
-			current = current.next
+			arcs[current].visited = true
+			current = arcs[current].next
 
-			if current.id == start.id {
+			if arcs[current].id == arcs[start].id {
 				break
 			}
 		}
 
 		loops = append(loops, outlineLoop{
-			root: start.root().id,
+			root: arcs[arcRoot(arcs, start)].id,
 			loop: verts,
 			area: CellBoundary(verts).areaRads2(),
 		})

--- a/x/h3go/multipoly_test.go
+++ b/x/h3go/multipoly_test.go
@@ -25,23 +25,28 @@ import (
 func TestUnionFind(t *testing.T) {
 	t.Parallel()
 
-	first := &arc{rank: 1}
-	first.parent = first
-	second := &arc{rank: 1}
-	second.parent = second
-	third := &arc{rank: 1}
-	third.parent = third
+	arcs := []arc{
+		{rank: 1, parent: 0},
+		{rank: 1, parent: 1},
+		{rank: 1, parent: 2},
+	}
+
+	const (
+		first  = 0
+		second = 1
+		third  = 2
+	)
 
 	// Equal ranks: no swap; first absorbs second.
-	union(first, second)
+	arcUnion(arcs, first, second)
 
 	// Lower-rank first absorbs into higher-rank component: triggers the swap.
-	union(third, first)
+	arcUnion(arcs, third, first)
 
 	// Already in the same component: the merge body is skipped.
-	union(second, third)
+	arcUnion(arcs, second, third)
 
-	if first.root() != second.root() || second.root() != third.root() {
+	if arcRoot(arcs, first) != arcRoot(arcs, second) || arcRoot(arcs, second) != arcRoot(arcs, third) {
 		t.Fatal("all arcs should share one root after the unions")
 	}
 }

--- a/x/h3go/paritytest/bench_fixtures_test.go
+++ b/x/h3go/paritytest/bench_fixtures_test.go
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2026 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file holds the shared fixtures and harness for the cross-implementation
+// benchmarks in bench_test.go. Every public symbol is benchmarked twice, once
+// against the cgo-backed github.com/uber/h3-go/v4 reference and once against the
+// pure-Go x/h3go package, under sub-benchmarks named "impl=cgo" and "impl=go".
+// Running benchstat with -col /impl over the output pivots the two into a single
+// delta column per method.
+
+package paritytest
+
+import (
+	"testing"
+
+	"github.com/uber/h3-go/v4"
+	"github.com/uber/h3-go/v4/x/h3go"
+)
+
+// benchRes is the working resolution for the single-cell fixtures. Resolution 9
+// is fine enough to exercise the digit chain without producing unwieldy child or
+// disk sets.
+const benchRes = 9
+
+// benchPolyRes is the fill resolution for the polygon fixtures, kept coarse so
+// PolygonToCells returns in a reasonable time per iteration.
+const benchPolyRes = 8
+
+var (
+	// Geographic inputs. The two points sit a few kilometres apart in the San
+	// Francisco Bay Area so distance and path fixtures stay well-defined.
+	benchGeo    = h3.LatLng{Lat: 37.7749, Lng: -122.4194}
+	benchGeo2   = h3.LatLng{Lat: 37.3382, Lng: -121.8863}
+	benchGoGeo  = h3go.LatLng{Lat: benchGeo.Lat, Lng: benchGeo.Lng}
+	benchGoGeo2 = h3go.LatLng{Lat: benchGeo2.Lat, Lng: benchGeo2.Lng}
+
+	// Single-cell fixtures.
+	benchCell   = mustCell(h3.LatLngToCell(benchGeo, benchRes))
+	benchGoCell = h3goCell(benchCell)
+
+	// An immediate neighbour, used for directed edges, neighbour checks and
+	// local IJ coordinates (which are only defined near the origin).
+	benchNeighbor   = adjacentCell(benchCell)
+	benchGoNeighbor = h3goCell(benchNeighbor)
+
+	// A cell five rings out, giving grid distance and path a non-trivial span.
+	benchTarget   = ringCell(benchCell, 5)
+	benchGoTarget = h3goCell(benchTarget)
+
+	// Directed edge and vertex fixtures derived from the working cell.
+	benchEdge   = mustEdge(benchCell.DirectedEdge(benchNeighbor))
+	benchGoEdge = h3go.DirectedEdge(benchEdge)
+
+	benchVertex   = mustVertex(h3.CellToVertex(benchCell, 0))
+	benchGoVertex = h3go.Vertex(benchVertex)
+
+	// String fixtures for the parse paths.
+	benchCellStr   = benchCell.String()
+	benchEdgeStr   = benchEdge.String()
+	benchVertexStr = benchVertex.String()
+
+	// Hierarchy fixtures: a coarse parent and its full child set, which compacts
+	// back to the parent and uncompacts back to the children.
+	benchParent        = mustCell(benchCell.Parent(6))
+	benchChildren      = mustCells(benchParent.Children(benchRes))
+	benchGoChildren    = toGoCells(benchChildren)
+	benchUncompactIn   = []h3.Cell{benchParent}
+	benchGoUncompactIn = toGoCells(benchUncompactIn)
+
+	// A filled grid disk, reused as the input set for batch disk traversal and
+	// the contiguous region passed to CellsToMultiPolygon.
+	benchDisk   = mustCells(h3.GridDisk(benchCell, 4))
+	benchGoDisk = toGoCells(benchDisk)
+
+	// Local IJ coordinates of the neighbour relative to the working cell.
+	benchLocalIJ   = mustIJ(h3.CellToLocalIJ(benchCell, benchNeighbor))
+	benchGoLocalIJ = h3go.CoordIJ{I: benchLocalIJ.I, J: benchLocalIJ.J}
+
+	// A polygon with a hole, shared from the parity-test corpus.
+	benchPolygon   = regionPolygons()["with_hole"]
+	benchGoPolygon = toGoPolygon(benchPolygon)
+)
+
+// blackhole is the shared sink that keeps the compiler from eliminating the
+// benchmarked calls. Sub-benchmarks run sequentially, so a single sink is safe.
+var blackhole any
+
+// compare runs cgoFn and goFn as the "impl=cgo" and "impl=go" sub-benchmarks so
+// benchstat -col /impl can report the delta between the two implementations.
+func compare(b *testing.B, cgoFn, goFn func()) {
+	b.Helper()
+
+	b.Run("impl=cgo", func(b *testing.B) {
+		for b.Loop() {
+			cgoFn()
+		}
+	})
+
+	b.Run("impl=go", func(b *testing.B) {
+		for b.Loop() {
+			goFn()
+		}
+	})
+}
+
+// mustCell returns the cell or panics, for fixture construction only.
+func mustCell(cell h3.Cell, err error) h3.Cell {
+	if err != nil {
+		panic(err)
+	}
+
+	return cell
+}
+
+// mustCells returns the cell slice or panics, for fixture construction only.
+func mustCells(cells []h3.Cell, err error) []h3.Cell {
+	if err != nil {
+		panic(err)
+	}
+
+	return cells
+}
+
+// mustEdge returns the directed edge or panics, for fixture construction only.
+func mustEdge(edge h3.DirectedEdge, err error) h3.DirectedEdge {
+	if err != nil {
+		panic(err)
+	}
+
+	return edge
+}
+
+// mustVertex returns the vertex or panics, for fixture construction only.
+func mustVertex(vertex h3.Vertex, err error) h3.Vertex {
+	if err != nil {
+		panic(err)
+	}
+
+	return vertex
+}
+
+// mustIJ returns the IJ coordinate or panics, for fixture construction only.
+func mustIJ(ij h3.CoordIJ, err error) h3.CoordIJ {
+	if err != nil {
+		panic(err)
+	}
+
+	return ij
+}
+
+// adjacentCell returns an immediate neighbour of origin.
+func adjacentCell(origin h3.Cell) h3.Cell {
+	disk, err := h3.GridDisk(origin, 1)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, candidate := range disk {
+		if candidate != 0 && candidate != origin {
+			return candidate
+		}
+	}
+
+	panic("no adjacent cell found")
+}
+
+// ringCell returns a cell on the k-ring around origin.
+func ringCell(origin h3.Cell, k int) h3.Cell {
+	ring, err := h3.GridRing(origin, k)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, candidate := range ring {
+		if candidate != 0 {
+			return candidate
+		}
+	}
+
+	panic("empty ring")
+}

--- a/x/h3go/paritytest/bench_test.go
+++ b/x/h3go/paritytest/bench_test.go
@@ -1,0 +1,778 @@
+/*
+ * Copyright 2026 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package paritytest's benchmarks compare the cgo reference against the pure-Go
+// x/h3go package for every publicly exposed function and method. Each benchmark
+// runs both implementations as "impl=cgo" and "impl=go" sub-benchmarks; pivot
+// with `benchstat -col /impl` to read the per-method delta.
+package paritytest
+
+import (
+	"testing"
+
+	"github.com/uber/h3-go/v4"
+	"github.com/uber/h3-go/v4/x/h3go"
+)
+
+// ---------------------------------------------------------------------------
+// Conversion: lat/lng <-> cell, string <-> index
+// ---------------------------------------------------------------------------
+
+func BenchmarkLatLngToCell(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.LatLngToCell(benchGeo, benchRes); blackhole = out },
+		func() { out, _ := h3go.LatLngToCell(benchGoGeo, benchRes); blackhole = out },
+	)
+}
+
+func BenchmarkLatLngToCellString(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.LatLngToCellString(benchGeo.Lat, benchGeo.Lng, benchRes); blackhole = out },
+		func() { out, _ := h3go.LatLngToCellString(benchGoGeo.Lat, benchGoGeo.Lng, benchRes); blackhole = out },
+	)
+}
+
+func BenchmarkLatLngCell(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchGeo.Cell(benchRes); blackhole = out },
+		func() { out, _ := benchGoGeo.Cell(benchRes); blackhole = out },
+	)
+}
+
+func BenchmarkNewLatLng(b *testing.B) {
+	compare(b,
+		func() { blackhole = h3.NewLatLng(benchGeo.Lat, benchGeo.Lng) },
+		func() { blackhole = h3go.NewLatLng(benchGoGeo.Lat, benchGoGeo.Lng) },
+	)
+}
+
+func BenchmarkLatLngString(b *testing.B) {
+	compare(b,
+		func() { blackhole = benchGeo.String() },
+		func() { blackhole = benchGoGeo.String() },
+	)
+}
+
+func BenchmarkCellToLatLng(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.CellToLatLng(benchCell); blackhole = out },
+		func() { out, _ := h3go.CellToLatLng(benchGoCell); blackhole = out },
+	)
+}
+
+func BenchmarkCellLatLng(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchCell.LatLng(); blackhole = out },
+		func() { out, _ := benchGoCell.LatLng(); blackhole = out },
+	)
+}
+
+func BenchmarkCellToString(b *testing.B) {
+	compare(b,
+		func() { blackhole = h3.CellToString(benchCell) },
+		func() { blackhole = h3go.CellToString(benchGoCell) },
+	)
+}
+
+func BenchmarkCellString(b *testing.B) {
+	compare(b,
+		func() { blackhole = benchCell.String() },
+		func() { blackhole = benchGoCell.String() },
+	)
+}
+
+func BenchmarkCellMarshalText(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchCell.MarshalText(); blackhole = out },
+		func() { out, _ := benchGoCell.MarshalText(); blackhole = out },
+	)
+}
+
+func BenchmarkCellFromString(b *testing.B) {
+	compare(b,
+		func() { blackhole = h3.CellFromString(benchCellStr) },
+		func() { blackhole = h3go.CellFromString(benchCellStr) },
+	)
+}
+
+func BenchmarkIndexFromString(b *testing.B) {
+	compare(b,
+		func() { blackhole = h3.IndexFromString(benchCellStr) },
+		func() { blackhole = h3go.IndexFromString(benchCellStr) },
+	)
+}
+
+func BenchmarkIndexToString(b *testing.B) {
+	compare(b,
+		func() { blackhole = h3.IndexToString(uint64(benchCell)) },
+		func() { blackhole = h3go.IndexToString(uint64(benchGoCell)) },
+	)
+}
+
+// ---------------------------------------------------------------------------
+// Index introspection
+// ---------------------------------------------------------------------------
+
+func BenchmarkResolution(b *testing.B) {
+	compare(b,
+		func() { blackhole = benchCell.Resolution() },
+		func() { blackhole = benchGoCell.Resolution() },
+	)
+}
+
+func BenchmarkBaseCellNumberFunc(b *testing.B) {
+	compare(b,
+		func() { blackhole = h3.BaseCellNumber(benchCell) },
+		func() { blackhole = h3go.BaseCellNumber(benchGoCell) },
+	)
+}
+
+func BenchmarkBaseCellNumber(b *testing.B) {
+	compare(b,
+		func() { blackhole = benchCell.BaseCellNumber() },
+		func() { blackhole = benchGoCell.BaseCellNumber() },
+	)
+}
+
+func BenchmarkIsValid(b *testing.B) {
+	compare(b,
+		func() { blackhole = benchCell.IsValid() },
+		func() { blackhole = benchGoCell.IsValid() },
+	)
+}
+
+func BenchmarkIsPentagon(b *testing.B) {
+	compare(b,
+		func() { blackhole = benchCell.IsPentagon() },
+		func() { blackhole = benchGoCell.IsPentagon() },
+	)
+}
+
+func BenchmarkIsResClassIII(b *testing.B) {
+	compare(b,
+		func() { blackhole = benchCell.IsResClassIII() },
+		func() { blackhole = benchGoCell.IsResClassIII() },
+	)
+}
+
+func BenchmarkCellIndexDigit(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchCell.IndexDigit(benchRes); blackhole = out },
+		func() { out, _ := benchGoCell.IndexDigit(benchRes); blackhole = out },
+	)
+}
+
+func BenchmarkNumCells(b *testing.B) {
+	compare(b,
+		func() { blackhole = h3.NumCells(benchRes) },
+		func() { blackhole = h3go.NumCells(benchRes) },
+	)
+}
+
+func BenchmarkRes0Cells(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.Res0Cells(); blackhole = out },
+		func() { out, _ := h3go.Res0Cells(); blackhole = out },
+	)
+}
+
+func BenchmarkPentagons(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.Pentagons(benchRes); blackhole = out },
+		func() { out, _ := h3go.Pentagons(benchRes); blackhole = out },
+	)
+}
+
+// ---------------------------------------------------------------------------
+// Hierarchy
+// ---------------------------------------------------------------------------
+
+func BenchmarkParent(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchCell.Parent(6); blackhole = out },
+		func() { out, _ := benchGoCell.Parent(6); blackhole = out },
+	)
+}
+
+func BenchmarkImmediateParent(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchCell.ImmediateParent(); blackhole = out },
+		func() { out, _ := benchGoCell.ImmediateParent(); blackhole = out },
+	)
+}
+
+func BenchmarkChildren(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchParent.Children(benchRes); blackhole = out },
+		func() { out, _ := h3goCell(benchParent).Children(benchRes); blackhole = out },
+	)
+}
+
+func BenchmarkImmediateChildren(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchCell.ImmediateChildren(); blackhole = out },
+		func() { out, _ := benchGoCell.ImmediateChildren(); blackhole = out },
+	)
+}
+
+func BenchmarkCenterChild(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchCell.CenterChild(benchRes + 2); blackhole = out },
+		func() { out, _ := benchGoCell.CenterChild(benchRes + 2); blackhole = out },
+	)
+}
+
+func BenchmarkCellToChildPos(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.CellToChildPos(benchCell, 6); blackhole = out },
+		func() { out, _ := h3go.CellToChildPos(benchGoCell, 6); blackhole = out },
+	)
+}
+
+func BenchmarkChildPos(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchCell.ChildPos(6); blackhole = out },
+		func() { out, _ := benchGoCell.ChildPos(6); blackhole = out },
+	)
+}
+
+func BenchmarkChildPosToCellFunc(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.ChildPosToCell(0, benchParent, benchRes); blackhole = out },
+		func() { out, _ := h3go.ChildPosToCell(0, h3goCell(benchParent), benchRes); blackhole = out },
+	)
+}
+
+func BenchmarkChildPosToCell(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchParent.ChildPosToCell(0, benchRes); blackhole = out },
+		func() { out, _ := h3goCell(benchParent).ChildPosToCell(0, benchRes); blackhole = out },
+	)
+}
+
+func BenchmarkCompactCells(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.CompactCells(benchChildren); blackhole = out },
+		func() { out, _ := h3go.CompactCells(benchGoChildren); blackhole = out },
+	)
+}
+
+func BenchmarkUncompactCells(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.UncompactCells(benchUncompactIn, benchRes); blackhole = out },
+		func() { out, _ := h3go.UncompactCells(benchGoUncompactIn, benchRes); blackhole = out },
+	)
+}
+
+// ---------------------------------------------------------------------------
+// Boundary
+// ---------------------------------------------------------------------------
+
+func BenchmarkCellToBoundary(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.CellToBoundary(benchCell); blackhole = out },
+		func() { out, _ := h3go.CellToBoundary(benchGoCell); blackhole = out },
+	)
+}
+
+func BenchmarkCellBoundary(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchCell.Boundary(); blackhole = out },
+		func() { out, _ := benchGoCell.Boundary(); blackhole = out },
+	)
+}
+
+// ---------------------------------------------------------------------------
+// Measures: area, edge length, great-circle distance
+// ---------------------------------------------------------------------------
+
+func BenchmarkCellAreaRads2(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.CellAreaRads2(benchCell); blackhole = out },
+		func() { out, _ := h3go.CellAreaRads2(benchGoCell); blackhole = out },
+	)
+}
+
+func BenchmarkCellAreaKm2(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.CellAreaKm2(benchCell); blackhole = out },
+		func() { out, _ := h3go.CellAreaKm2(benchGoCell); blackhole = out },
+	)
+}
+
+func BenchmarkCellAreaM2(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.CellAreaM2(benchCell); blackhole = out },
+		func() { out, _ := h3go.CellAreaM2(benchGoCell); blackhole = out },
+	)
+}
+
+func BenchmarkHexagonAreaAvgKm2(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.HexagonAreaAvgKm2(benchRes); blackhole = out },
+		func() { out, _ := h3go.HexagonAreaAvgKm2(benchRes); blackhole = out },
+	)
+}
+
+func BenchmarkHexagonAreaAvgM2(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.HexagonAreaAvgM2(benchRes); blackhole = out },
+		func() { out, _ := h3go.HexagonAreaAvgM2(benchRes); blackhole = out },
+	)
+}
+
+func BenchmarkEdgeLengthRads(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.EdgeLengthRads(benchEdge); blackhole = out },
+		func() { out, _ := h3go.EdgeLengthRads(benchGoEdge); blackhole = out },
+	)
+}
+
+func BenchmarkEdgeLengthKm(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.EdgeLengthKm(benchEdge); blackhole = out },
+		func() { out, _ := h3go.EdgeLengthKm(benchGoEdge); blackhole = out },
+	)
+}
+
+func BenchmarkEdgeLengthM(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.EdgeLengthM(benchEdge); blackhole = out },
+		func() { out, _ := h3go.EdgeLengthM(benchGoEdge); blackhole = out },
+	)
+}
+
+func BenchmarkHexagonEdgeLengthAvgKm(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.HexagonEdgeLengthAvgKm(benchRes); blackhole = out },
+		func() { out, _ := h3go.HexagonEdgeLengthAvgKm(benchRes); blackhole = out },
+	)
+}
+
+func BenchmarkHexagonEdgeLengthAvgM(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.HexagonEdgeLengthAvgM(benchRes); blackhole = out },
+		func() { out, _ := h3go.HexagonEdgeLengthAvgM(benchRes); blackhole = out },
+	)
+}
+
+func BenchmarkGreatCircleDistanceRads(b *testing.B) {
+	compare(b,
+		func() { blackhole = h3.GreatCircleDistanceRads(benchGeo, benchGeo2) },
+		func() { blackhole = h3go.GreatCircleDistanceRads(benchGoGeo, benchGoGeo2) },
+	)
+}
+
+func BenchmarkGreatCircleDistanceKm(b *testing.B) {
+	compare(b,
+		func() { blackhole = h3.GreatCircleDistanceKm(benchGeo, benchGeo2) },
+		func() { blackhole = h3go.GreatCircleDistanceKm(benchGoGeo, benchGoGeo2) },
+	)
+}
+
+func BenchmarkGreatCircleDistanceM(b *testing.B) {
+	compare(b,
+		func() { blackhole = h3.GreatCircleDistanceM(benchGeo, benchGeo2) },
+		func() { blackhole = h3go.GreatCircleDistanceM(benchGoGeo, benchGoGeo2) },
+	)
+}
+
+// ---------------------------------------------------------------------------
+// Grid traversal
+// ---------------------------------------------------------------------------
+
+func BenchmarkGridDiskFunc(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.GridDisk(benchCell, 5); blackhole = out },
+		func() { out, _ := h3go.GridDisk(benchGoCell, 5); blackhole = out },
+	)
+}
+
+func BenchmarkGridDisk(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchCell.GridDisk(5); blackhole = out },
+		func() { out, _ := benchGoCell.GridDisk(5); blackhole = out },
+	)
+}
+
+func BenchmarkGridDiskDistancesFunc(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.GridDiskDistances(benchCell, 5); blackhole = out },
+		func() { out, _ := h3go.GridDiskDistances(benchGoCell, 5); blackhole = out },
+	)
+}
+
+func BenchmarkGridDiskDistances(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchCell.GridDiskDistances(5); blackhole = out },
+		func() { out, _ := benchGoCell.GridDiskDistances(5); blackhole = out },
+	)
+}
+
+func BenchmarkGridDiskDistancesSafeFunc(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.GridDiskDistancesSafe(benchCell, 5); blackhole = out },
+		func() { out, _ := h3go.GridDiskDistancesSafe(benchGoCell, 5); blackhole = out },
+	)
+}
+
+func BenchmarkGridDiskDistancesSafe(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchCell.GridDiskDistancesSafe(5); blackhole = out },
+		func() { out, _ := benchGoCell.GridDiskDistancesSafe(5); blackhole = out },
+	)
+}
+
+func BenchmarkGridDiskDistancesUnsafeFunc(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.GridDiskDistancesUnsafe(benchCell, 5); blackhole = out },
+		func() { out, _ := h3go.GridDiskDistancesUnsafe(benchGoCell, 5); blackhole = out },
+	)
+}
+
+func BenchmarkGridDiskDistancesUnsafe(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchCell.GridDiskDistancesUnsafe(5); blackhole = out },
+		func() { out, _ := benchGoCell.GridDiskDistancesUnsafe(5); blackhole = out },
+	)
+}
+
+func BenchmarkGridRingFunc(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.GridRing(benchCell, 5); blackhole = out },
+		func() { out, _ := h3go.GridRing(benchGoCell, 5); blackhole = out },
+	)
+}
+
+func BenchmarkGridRing(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchCell.GridRing(5); blackhole = out },
+		func() { out, _ := benchGoCell.GridRing(5); blackhole = out },
+	)
+}
+
+func BenchmarkGridRingUnsafeFunc(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.GridRingUnsafe(benchCell, 5); blackhole = out },
+		func() { out, _ := h3go.GridRingUnsafe(benchGoCell, 5); blackhole = out },
+	)
+}
+
+func BenchmarkGridRingUnsafe(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchCell.GridRingUnsafe(5); blackhole = out },
+		func() { out, _ := benchGoCell.GridRingUnsafe(5); blackhole = out },
+	)
+}
+
+func BenchmarkGridDisksUnsafe(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.GridDisksUnsafe(benchDisk, 3); blackhole = out },
+		func() { out, _ := h3go.GridDisksUnsafe(benchGoDisk, 3); blackhole = out },
+	)
+}
+
+func BenchmarkGridDistanceFunc(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.GridDistance(benchCell, benchTarget); blackhole = out },
+		func() { out, _ := h3go.GridDistance(benchGoCell, benchGoTarget); blackhole = out },
+	)
+}
+
+func BenchmarkGridDistance(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchCell.GridDistance(benchTarget); blackhole = out },
+		func() { out, _ := benchGoCell.GridDistance(benchGoTarget); blackhole = out },
+	)
+}
+
+func BenchmarkGridPathFunc(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.GridPath(benchCell, benchTarget); blackhole = out },
+		func() { out, _ := h3go.GridPath(benchGoCell, benchGoTarget); blackhole = out },
+	)
+}
+
+func BenchmarkGridPath(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchCell.GridPath(benchTarget); blackhole = out },
+		func() { out, _ := benchGoCell.GridPath(benchGoTarget); blackhole = out },
+	)
+}
+
+func BenchmarkIsNeighbor(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchCell.IsNeighbor(benchNeighbor); blackhole = out },
+		func() { out, _ := benchGoCell.IsNeighbor(benchGoNeighbor); blackhole = out },
+	)
+}
+
+// ---------------------------------------------------------------------------
+// Local IJ coordinates
+// ---------------------------------------------------------------------------
+
+func BenchmarkCellToLocalIJ(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.CellToLocalIJ(benchCell, benchNeighbor); blackhole = out },
+		func() { out, _ := h3go.CellToLocalIJ(benchGoCell, benchGoNeighbor); blackhole = out },
+	)
+}
+
+func BenchmarkLocalIJToCell(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.LocalIJToCell(benchCell, benchLocalIJ); blackhole = out },
+		func() { out, _ := h3go.LocalIJToCell(benchGoCell, benchGoLocalIJ); blackhole = out },
+	)
+}
+
+// ---------------------------------------------------------------------------
+// Icosahedron faces
+// ---------------------------------------------------------------------------
+
+func BenchmarkIcosahedronFaces(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchCell.IcosahedronFaces(); blackhole = out },
+		func() { out, _ := benchGoCell.IcosahedronFaces(); blackhole = out },
+	)
+}
+
+// ---------------------------------------------------------------------------
+// Vertexes
+// ---------------------------------------------------------------------------
+
+func BenchmarkCellToVertex(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.CellToVertex(benchCell, 0); blackhole = out },
+		func() { out, _ := h3go.CellToVertex(benchGoCell, 0); blackhole = out },
+	)
+}
+
+func BenchmarkCellVertex(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchCell.Vertex(0); blackhole = out },
+		func() { out, _ := benchGoCell.Vertex(0); blackhole = out },
+	)
+}
+
+func BenchmarkCellToVertexes(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.CellToVertexes(benchCell); blackhole = out },
+		func() { out, _ := h3go.CellToVertexes(benchGoCell); blackhole = out },
+	)
+}
+
+func BenchmarkCellVertexes(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchCell.Vertexes(); blackhole = out },
+		func() { out, _ := benchGoCell.Vertexes(); blackhole = out },
+	)
+}
+
+func BenchmarkVertexToLatLng(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.VertexToLatLng(benchVertex); blackhole = out },
+		func() { out, _ := h3go.VertexToLatLng(benchGoVertex); blackhole = out },
+	)
+}
+
+func BenchmarkVertexLatLng(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchVertex.LatLng(); blackhole = out },
+		func() { out, _ := benchGoVertex.LatLng(); blackhole = out },
+	)
+}
+
+func BenchmarkIsValidVertexFunc(b *testing.B) {
+	compare(b,
+		func() { blackhole = h3.IsValidVertex(benchVertex) },
+		func() { blackhole = h3go.IsValidVertex(benchGoVertex) },
+	)
+}
+
+func BenchmarkVertexIsValid(b *testing.B) {
+	compare(b,
+		func() { blackhole = benchVertex.IsValid() },
+		func() { blackhole = benchGoVertex.IsValid() },
+	)
+}
+
+func BenchmarkVertexResolution(b *testing.B) {
+	compare(b,
+		func() { blackhole = benchVertex.Resolution() },
+		func() { blackhole = benchGoVertex.Resolution() },
+	)
+}
+
+func BenchmarkVertexIndexDigit(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchVertex.IndexDigit(benchRes); blackhole = out },
+		func() { out, _ := benchGoVertex.IndexDigit(benchRes); blackhole = out },
+	)
+}
+
+func BenchmarkVertexString(b *testing.B) {
+	compare(b,
+		func() { blackhole = benchVertex.String() },
+		func() { blackhole = benchGoVertex.String() },
+	)
+}
+
+func BenchmarkVertexMarshalText(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchVertex.MarshalText(); blackhole = out },
+		func() { out, _ := benchGoVertex.MarshalText(); blackhole = out },
+	)
+}
+
+func BenchmarkVertexFromString(b *testing.B) {
+	compare(b,
+		func() { blackhole = h3.VertexFromString(benchVertexStr) },
+		func() { blackhole = h3go.VertexFromString(benchVertexStr) },
+	)
+}
+
+// ---------------------------------------------------------------------------
+// Directed edges
+// ---------------------------------------------------------------------------
+
+func BenchmarkDirectedEdge(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchCell.DirectedEdge(benchNeighbor); blackhole = out },
+		func() { out, _ := benchGoCell.DirectedEdge(benchGoNeighbor); blackhole = out },
+	)
+}
+
+func BenchmarkDirectedEdges(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchCell.DirectedEdges(); blackhole = out },
+		func() { out, _ := benchGoCell.DirectedEdges(); blackhole = out },
+	)
+}
+
+func BenchmarkDirectedEdgeCells(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchEdge.Cells(); blackhole = out },
+		func() { out, _ := benchGoEdge.Cells(); blackhole = out },
+	)
+}
+
+func BenchmarkDirectedEdgeOrigin(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchEdge.Origin(); blackhole = out },
+		func() { out, _ := benchGoEdge.Origin(); blackhole = out },
+	)
+}
+
+func BenchmarkDirectedEdgeDestination(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchEdge.Destination(); blackhole = out },
+		func() { out, _ := benchGoEdge.Destination(); blackhole = out },
+	)
+}
+
+func BenchmarkDirectedEdgeReverse(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchEdge.Reverse(); blackhole = out },
+		func() { out, _ := benchGoEdge.Reverse(); blackhole = out },
+	)
+}
+
+func BenchmarkDirectedEdgeIsValid(b *testing.B) {
+	compare(b,
+		func() { blackhole = benchEdge.IsValid() },
+		func() { blackhole = benchGoEdge.IsValid() },
+	)
+}
+
+func BenchmarkDirectedEdgeResolution(b *testing.B) {
+	compare(b,
+		func() { blackhole = benchEdge.Resolution() },
+		func() { blackhole = benchGoEdge.Resolution() },
+	)
+}
+
+func BenchmarkDirectedEdgeIndexDigit(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchEdge.IndexDigit(benchRes); blackhole = out },
+		func() { out, _ := benchGoEdge.IndexDigit(benchRes); blackhole = out },
+	)
+}
+
+func BenchmarkDirectedEdgeBoundary(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchEdge.Boundary(); blackhole = out },
+		func() { out, _ := benchGoEdge.Boundary(); blackhole = out },
+	)
+}
+
+func BenchmarkDirectedEdgeString(b *testing.B) {
+	compare(b,
+		func() { blackhole = benchEdge.String() },
+		func() { blackhole = benchGoEdge.String() },
+	)
+}
+
+func BenchmarkDirectedEdgeMarshalText(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchEdge.MarshalText(); blackhole = out },
+		func() { out, _ := benchGoEdge.MarshalText(); blackhole = out },
+	)
+}
+
+func BenchmarkDirectedEdgeFromString(b *testing.B) {
+	compare(b,
+		func() { blackhole = h3.DirectedEdgeFromString(benchEdgeStr) },
+		func() { blackhole = h3go.DirectedEdgeFromString(benchEdgeStr) },
+	)
+}
+
+// ---------------------------------------------------------------------------
+// Regions: polygon <-> cells
+// ---------------------------------------------------------------------------
+
+func BenchmarkPolygonToCells(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.PolygonToCells(benchPolygon, benchPolyRes); blackhole = out },
+		func() { out, _ := h3go.PolygonToCells(benchGoPolygon, benchPolyRes); blackhole = out },
+	)
+}
+
+func BenchmarkGeoPolygonCells(b *testing.B) {
+	compare(b,
+		func() { out, _ := benchPolygon.Cells(benchPolyRes); blackhole = out },
+		func() { out, _ := benchGoPolygon.Cells(benchPolyRes); blackhole = out },
+	)
+}
+
+func BenchmarkPolygonToCellsExperimental(b *testing.B) {
+	compare(b,
+		func() {
+			out, _ := h3.PolygonToCellsExperimental(benchPolygon, benchPolyRes, h3.ContainmentCenter)
+			blackhole = out
+		},
+		func() {
+			out, _ := h3go.PolygonToCellsExperimental(benchGoPolygon, benchPolyRes, h3go.ContainmentCenter)
+			blackhole = out
+		},
+	)
+}
+
+func BenchmarkCellsToMultiPolygon(b *testing.B) {
+	compare(b,
+		func() { out, _ := h3.CellsToMultiPolygon(benchDisk); blackhole = out },
+		func() { out, _ := h3go.CellsToMultiPolygon(benchGoDisk); blackhole = out },
+	)
+}

--- a/x/h3go/region.go
+++ b/x/h3go/region.go
@@ -144,10 +144,14 @@ func PolygonToCells(polygon GeoPolygon, res int) ([]Cell, error) {
 func polygonFloodStep(polygon GeoPolygon, bboxes []bbox, searchList []Cell, found map[Cell]bool) []Cell {
 	var nextSearch []Cell
 
-	for _, searchHex := range searchList {
-		ring, _ := searchHex.GridDisk(1)
+	// disk is reused across cells so the grid-disk lookup below allocates once
+	// rather than once per search cell.
+	var disk []Cell
 
-		for _, hex := range ring {
+	for _, searchHex := range searchList {
+		disk, _ = searchHex.gridDiskInto(1, disk[:0])
+
+		for _, hex := range disk {
 			if found[hex] {
 				continue
 			}


### PR DESCRIPTION
Add a cgo-vs-pure-Go benchmark suite under x/h3go/paritytest covering every publicly exposed function and method, each run as "impl=cgo" and "impl=go" sub-benchmarks so `benchstat -col /impl` reports the per-method delta.

Drive down allocations in the functions the suite flagged as far slower than the cgo reference, replacing append-growth, per-call disk allocation, per-level maps, and a pointer-per-arc graph with preallocated/shared buffers and index-based structures (measured pure-Go before -> after, Apple M3 Max):

- GridDisk:            36 -> 2 allocs,  1610ns -> 837ns  (now -18% vs cgo)
- GridDisksUnsafe:   1283 -> 3 allocs, 49.3us -> 22.3us  (now -24% vs cgo)
- GridDiskDistances:   30 -> 3 allocs, -35% time
- GridRing(Unsafe):     5 -> 2 allocs, -15% time
- PolygonToCells:    2526 -> 98 allocs, -20% time
- CellsToMultiPolygon: 632 -> 188 allocs, -25% time
- CompactCells: rewritten map-based -> sort-based, 10.8us -> 1.70us
  (now -38% vs cgo, was +330%)

Also restore the Class III substrate aperture-7 scaling branch in faceijk.toVec3 for byte-for-byte fidelity with the C reference (dead code for H3's own callers, which bump substrate grids to Class II first).


benchstat -col /impl over the full suite (Apple M3 Max, count=10, benchtime=100ms). 'go' is this pure-Go package, 'cgo' the v4 reference:

```
                               │      cgo      │                  go                  │
                               │    sec/op     │    sec/op     vs base                │
LatLngToCell-16                   236.2n ±  7%    223.1n ± 1%   -5.55% (p=0.000 n=10)
LatLngToCellString-16             262.8n ±  0%    245.9n ± 1%   -6.43% (p=0.000 n=10)
LatLngCell-16                     236.2n ±  3%    222.6n ± 1%   -5.76% (p=0.000 n=10)
NewLatLng-16                      9.533n ±  2%    9.468n ± 1%        ~ (p=0.052 n=10)
LatLngString-16                   70.71n ±  5%    69.61n ± 2%        ~ (p=0.050 n=10)
CellToLatLng-16                   150.2n ±  0%    158.8n ± 0%   +5.73% (p=0.000 n=10)
CellLatLng-16                     150.2n ±  1%    158.1n ± 0%   +5.33% (p=0.000 n=10)
CellToString-16                   29.70n ±  2%    29.43n ± 1%   -0.91% (p=0.006 n=10)
CellString-16                     29.48n ±  4%    29.14n ± 0%   -1.12% (p=0.003 n=10)
CellMarshalText-16                47.57n ±  0%    46.47n ± 0%   -2.32% (p=0.001 n=10)
CellFromString-16                 31.97n ±  3%    31.46n ± 2%   -1.58% (p=0.011 n=10)
IndexFromString-16                31.71n ±  5%    32.38n ± 2%   +2.11% (p=0.024 n=10)
IndexToString-16                  30.08n ± 10%    29.11n ± 1%   -3.24% (p=0.000 n=10)
Resolution-16                     1.936n ±  1%    1.935n ± 4%        ~ (p=0.696 n=10)
BaseCellNumberFunc-16             1.934n ±  0%    1.940n ± 3%        ~ (p=0.109 n=10)
BaseCellNumber-16                 1.921n ±  0%    1.921n ± 3%        ~ (p=0.839 n=10)
IsValid-16                        2.662n ±  0%    2.461n ± 3%   -7.53% (p=0.000 n=10)
IsPentagon-16                     1.940n ±  5%    1.910n ± 0%   -1.52% (p=0.000 n=10)
IsResClassIII-16                  1.891n ±  1%    1.878n ± 1%   -0.71% (p=0.000 n=10)
CellIndexDigit-16                30.765n ±  1%    1.936n ± 1%  -93.71% (p=0.000 n=10)
NumCells-16                       7.825n ±  1%    7.969n ± 4%   +1.85% (p=0.009 n=10)
Res0Cells-16                      190.8n ±  1%    140.9n ± 1%  -26.11% (p=0.000 n=10)
Pentagons-16                      254.0n ±  1%    121.8n ± 0%  -52.02% (p=0.000 n=10)
Parent-16                         37.26n ±  2%    12.25n ± 1%  -67.14% (p=0.000 n=10)
ImmediateParent-16                36.41n ±  0%    10.26n ± 1%  -71.83% (p=0.000 n=10)
Children-16                      1533.5n ±  2%    856.1n ± 1%  -44.17% (p=0.000 n=10)
ImmediateChildren-16             106.45n ±  2%    44.43n ± 1%  -58.26% (p=0.000 n=10)
CenterChild-16                   36.550n ±  4%    8.892n ± 1%  -75.67% (p=0.000 n=10)
CellToChildPos-16                 41.72n ±  1%    10.33n ± 4%  -75.24% (p=0.000 n=10)
ChildPos-16                       42.04n ±  1%    10.32n ± 1%  -75.45% (p=0.000 n=10)
ChildPosToCellFunc-16             45.41n ±  6%    14.46n ± 1%  -68.14% (p=0.000 n=10)
ChildPosToCell-16                 44.67n ±  1%    14.91n ± 2%  -66.63% (p=0.000 n=10)
CompactCells-16                   2.679µ ±  1%    1.636µ ± 0%  -38.95% (p=0.000 n=10)
UncompactCells-16                1723.5n ±  4%    853.0n ± 0%  -50.50% (p=0.000 n=10)
CellToBoundary-16                 484.8n ±  1%    651.1n ± 2%  +34.30% (p=0.000 n=10)
CellBoundary-16                   485.4n ±  1%    650.9n ± 0%  +34.10% (p=0.000 n=10)
CellAreaRads2-16                  561.2n ±  1%    819.2n ± 1%  +45.96% (p=0.000 n=10)
CellAreaKm2-16                    561.1n ±  0%    816.4n ± 0%  +45.49% (p=0.000 n=10)
CellAreaM2-16                     563.1n ±  1%    825.6n ± 7%  +46.61% (p=0.000 n=10)
HexagonAreaAvgKm2-16             35.590n ±  1%    7.878n ± 3%  -77.86% (p=0.000 n=10)
HexagonAreaAvgM2-16              35.885n ±  0%    7.792n ± 9%  -78.29% (p=0.000 n=10)
EdgeLengthRads-16                 287.2n ±  0%    392.5n ± 2%  +36.64% (p=0.000 n=10)
EdgeLengthKm-16                   289.1n ±  0%    392.1n ± 0%  +35.65% (p=0.000 n=10)
EdgeLengthM-16                    293.0n ±  4%    394.4n ± 0%  +34.60% (p=0.000 n=10)
HexagonEdgeLengthAvgKm-16        35.630n ±  3%    8.010n ± 2%  -77.52% (p=0.000 n=10)
HexagonEdgeLengthAvgM-16         35.610n ±  0%    8.108n ± 2%  -77.23% (p=0.000 n=10)
GreatCircleDistanceRads-16        30.25n ±  3%    29.84n ± 1%   -1.34% (p=0.001 n=10)
GreatCircleDistanceKm-16          30.34n ±  0%    30.32n ± 0%        ~ (p=0.697 n=10)
GreatCircleDistanceM-16           30.95n ±  0%    30.93n ± 0%        ~ (p=0.445 n=10)
GridDiskFunc-16                  1057.5n ±  1%    861.2n ± 1%  -18.56% (p=0.000 n=10)
GridDisk-16                      1066.5n ±  1%    862.5n ± 0%  -19.13% (p=0.000 n=10)
GridDiskDistancesFunc-16         1360.5n ±  2%    899.9n ± 1%  -33.86% (p=0.000 n=10)
GridDiskDistances-16             1339.5n ±  0%    893.2n ± 0%  -33.32% (p=0.000 n=10)
GridDiskDistancesSafeFunc-16      7.010µ ±  1%    7.603µ ± 1%   +8.46% (p=0.000 n=10)
GridDiskDistancesSafe-16          6.963µ ±  2%    7.641µ ± 1%   +9.74% (p=0.000 n=10)
GridDiskDistancesUnsafeFunc-16   1344.5n ±  1%    903.6n ± 1%  -32.79% (p=0.000 n=10)
GridDiskDistancesUnsafe-16       1343.5n ±  6%    897.5n ± 3%  -33.20% (p=0.000 n=10)
GridRingFunc-16                   417.1n ±  3%    349.1n ± 3%  -16.30% (p=0.000 n=10)
GridRing-16                       421.2n ±  5%    347.8n ± 0%  -17.41% (p=0.000 n=10)
GridRingUnsafeFunc-16             422.3n ±  1%    347.2n ± 0%  -17.77% (p=0.000 n=10)
GridRingUnsafe-16                 418.6n ±  1%    347.4n ± 1%  -17.01% (p=0.000 n=10)
GridDisksUnsafe-16                29.24µ ±  4%    22.96µ ± 1%  -21.47% (p=0.000 n=10)
GridDistanceFunc-16               76.82n ±  1%   146.20n ± 1%  +90.32% (p=0.000 n=10)
GridDistance-16                   77.68n ±  4%   146.80n ± 1%  +88.97% (p=0.000 n=10)
GridPathFunc-16                   861.7n ±  1%    960.7n ± 1%  +11.48% (p=0.000 n=10)
GridPath-16                       856.1n ±  0%    961.3n ± 1%  +12.28% (p=0.000 n=10)
IsNeighbor-16                    33.255n ±  1%    5.869n ± 3%  -82.35% (p=0.000 n=10)
CellToLocalIJ-16                  62.25n ±  2%    72.22n ± 4%  +16.02% (p=0.000 n=10)
LocalIJToCell-16                  145.6n ±  0%    105.5n ± 1%  -27.55% (p=0.000 n=10)
IcosahedronFaces-16               139.4n ±  5%    153.1n ± 1%   +9.79% (p=0.000 n=10)
CellToVertex-16                  37.290n ±  1%    9.367n ± 1%  -74.88% (p=0.000 n=10)
CellVertex-16                    37.145n ±  1%    9.325n ± 1%  -74.90% (p=0.000 n=10)
CellToVertexes-16                 77.33n ±  3%    44.19n ± 1%  -42.86% (p=0.000 n=10)
CellVertexes-16                   76.14n ±  5%    44.09n ± 1%  -42.10% (p=0.000 n=10)
VertexToLatLng-16                 176.7n ±  1%    215.6n ± 2%  +21.98% (p=0.000 n=10)
VertexLatLng-16                   176.2n ±  0%    215.8n ± 2%  +22.41% (p=0.000 n=10)
IsValidVertexFunc-16             21.960n ±  1%    5.058n ± 1%  -76.97% (p=0.000 n=10)
VertexIsValid-16                 22.050n ±  1%    4.786n ± 0%  -78.29% (p=0.000 n=10)
VertexResolution-16               1.920n ±  0%    1.932n ± 0%   +0.65% (p=0.018 n=10)
VertexIndexDigit-16              30.790n ±  2%    1.921n ± 0%  -93.76% (p=0.000 n=10)
VertexString-16                   29.28n ±  2%    29.27n ± 1%        ~ (p=0.781 n=10)
VertexMarshalText-16              45.75n ±  1%    45.01n ± 1%   -1.63% (p=0.001 n=10)
VertexFromString-16               32.32n ±  5%    32.18n ± 2%        ~ (p=0.839 n=10)
DirectedEdge-16                   71.26n ±  6%    46.38n ± 1%  -34.91% (p=0.000 n=10)
DirectedEdges-16                  58.66n ±  1%    34.05n ± 1%  -41.95% (p=0.000 n=10)
DirectedEdgeCells-16              56.19n ±  1%    32.05n ± 1%  -42.95% (p=0.000 n=10)
DirectedEdgeOrigin-16            35.470n ±  4%    8.356n ± 2%  -76.44% (p=0.000 n=10)
DirectedEdgeDestination-16        40.53n ±  1%    14.55n ± 1%  -64.10% (p=0.000 n=10)
DirectedEdgeReverse-16            49.16n ±  1%    22.89n ± 1%  -53.45% (p=0.000 n=10)
DirectedEdgeIsValid-16           21.080n ±  2%    3.522n ± 0%  -83.29% (p=0.000 n=10)
DirectedEdgeResolution-16         1.936n ±  0%    1.937n ± 1%        ~ (p=0.643 n=10)
DirectedEdgeIndexDigit-16        30.615n ±  1%    1.919n ± 1%  -93.73% (p=0.000 n=10)
DirectedEdgeBoundary-16           285.8n ±  1%    376.6n ± 1%  +31.75% (p=0.000 n=10)
DirectedEdgeString-16             29.61n ±  2%    29.41n ± 2%        ~ (p=0.210 n=10)
DirectedEdgeMarshalText-16        46.40n ±  1%    45.12n ± 1%   -2.76% (p=0.000 n=10)
DirectedEdgeFromString-16         32.18n ±  5%    32.21n ± 4%        ~ (p=0.853 n=10)
PolygonToCells-16                 136.7µ ±  0%    188.9µ ± 1%  +38.26% (p=0.000 n=10)
GeoPolygonCells-16                136.5µ ±  1%    188.9µ ± 1%  +38.37% (p=0.000 n=10)
PolygonToCellsExperimental-16     203.9µ ±  1%    117.8µ ± 0%  -42.24% (p=0.000 n=10)
CellsToMultiPolygon-16            26.52µ ±  0%    39.42µ ± 2%  +48.65% (p=0.000 n=10)
geomean                           116.3n          78.02n       -32.92%

                               │      cgo       │                     go                      │
                               │      B/op      │     B/op       vs base                      │
LatLngToCell-16                   32.000 ± 0%        8.000 ± 0%    -75.00% (p=0.000 n=10)
LatLngToCellString-16              56.00 ± 0%        32.00 ± 0%    -42.86% (p=0.000 n=10)
LatLngCell-16                     32.000 ± 0%        8.000 ± 0%    -75.00% (p=0.000 n=10)
NewLatLng-16                       16.00 ± 0%        16.00 ± 0%          ~ (p=1.000 n=10) ¹
LatLngString-16                    40.00 ± 0%        40.00 ± 0%          ~ (p=1.000 n=10) ¹
CellToLatLng-16                    32.00 ± 0%        16.00 ± 0%    -50.00% (p=0.000 n=10)
CellLatLng-16                      32.00 ± 0%        16.00 ± 0%    -50.00% (p=0.000 n=10)
CellToString-16                    32.00 ± 0%        32.00 ± 0%          ~ (p=1.000 n=10) ¹
CellString-16                      32.00 ± 0%        32.00 ± 0%          ~ (p=1.000 n=10) ¹
CellMarshalText-16                 56.00 ± 0%        56.00 ± 0%          ~ (p=1.000 n=10) ¹
CellFromString-16                  8.000 ± 0%        8.000 ± 0%          ~ (p=1.000 n=10) ¹
IndexFromString-16                 8.000 ± 0%        8.000 ± 0%          ~ (p=1.000 n=10) ¹
IndexToString-16                   32.00 ± 0%        32.00 ± 0%          ~ (p=1.000 n=10) ¹
Resolution-16                      0.000 ± 0%        0.000 ± 0%          ~ (p=1.000 n=10) ¹
BaseCellNumberFunc-16              0.000 ± 0%        0.000 ± 0%          ~ (p=1.000 n=10) ¹
BaseCellNumber-16                  0.000 ± 0%        0.000 ± 0%          ~ (p=1.000 n=10) ¹
IsValid-16                         0.000 ± 0%        0.000 ± 0%          ~ (p=1.000 n=10) ¹
IsPentagon-16                      0.000 ± 0%        0.000 ± 0%          ~ (p=1.000 n=10) ¹
IsResClassIII-16                   0.000 ± 0%        0.000 ± 0%          ~ (p=1.000 n=10) ¹
CellIndexDigit-16                  4.000 ± 0%        0.000 ± 0%   -100.00% (p=0.000 n=10)
NumCells-16                        8.000 ± 0%        8.000 ± 0%          ~ (p=1.000 n=10) ¹
Res0Cells-16                     1.023Ki ± 0%      1.023Ki ± 0%          ~ (p=1.000 n=10) ¹
Pentagons-16                       120.0 ± 0%        120.0 ± 0%          ~ (p=1.000 n=10) ¹
Parent-16                         16.000 ± 0%        8.000 ± 0%    -50.00% (p=0.000 n=10)
ImmediateParent-16                16.000 ± 0%        8.000 ± 0%    -50.00% (p=0.000 n=10)
Children-16                      3.031Ki ± 0%      3.023Ki ± 0%     -0.26% (p=0.000 n=10)
ImmediateChildren-16               96.00 ± 0%        88.00 ± 0%     -8.33% (p=0.000 n=10)
CenterChild-16                    16.000 ± 0%        8.000 ± 0%    -50.00% (p=0.000 n=10)
CellToChildPos-16                  8.000 ± 0%        0.000 ± 0%   -100.00% (p=0.000 n=10)
ChildPos-16                        8.000 ± 0%        0.000 ± 0%   -100.00% (p=0.000 n=10)
ChildPosToCellFunc-16             16.000 ± 0%        8.000 ± 0%    -50.00% (p=0.000 n=10)
ChildPosToCell-16                 16.000 ± 0%        8.000 ± 0%    -50.00% (p=0.000 n=10)
CompactCells-16                  3.023Ki ± 0%      3.969Ki ± 0%    +31.27% (p=0.000 n=10)
UncompactCells-16                3.031Ki ± 0%      3.023Ki ± 0%     -0.26% (p=0.000 n=10)
CellToBoundary-16                  296.0 ± 0%        264.0 ± 0%    -10.81% (p=0.000 n=10)
CellBoundary-16                    296.0 ± 0%        264.0 ± 0%    -10.81% (p=0.000 n=10)
CellAreaRads2-16                   16.00 ± 0%       248.00 ± 0%  +1450.00% (p=0.000 n=10)
CellAreaKm2-16                     16.00 ± 0%       248.00 ± 0%  +1450.00% (p=0.000 n=10)
CellAreaM2-16                      16.00 ± 0%       248.00 ± 0%  +1450.00% (p=0.000 n=10)
HexagonAreaAvgKm2-16              16.000 ± 0%        8.000 ± 0%    -50.00% (p=0.000 n=10)
HexagonAreaAvgM2-16               16.000 ± 0%        8.000 ± 0%    -50.00% (p=0.000 n=10)
EdgeLengthRads-16                  16.00 ± 0%        56.00 ± 0%   +250.00% (p=0.000 n=10)
EdgeLengthKm-16                    16.00 ± 0%        56.00 ± 0%   +250.00% (p=0.000 n=10)
EdgeLengthM-16                     16.00 ± 0%        56.00 ± 0%   +250.00% (p=0.000 n=10)
HexagonEdgeLengthAvgKm-16         16.000 ± 0%        8.000 ± 0%    -50.00% (p=0.000 n=10)
HexagonEdgeLengthAvgM-16          16.000 ± 0%        8.000 ± 0%    -50.00% (p=0.000 n=10)
GreatCircleDistanceRads-16         8.000 ± 0%        8.000 ± 0%          ~ (p=1.000 n=10) ¹
GreatCircleDistanceKm-16           8.000 ± 0%        8.000 ± 0%          ~ (p=1.000 n=10) ¹
GreatCircleDistanceM-16            8.000 ± 0%        8.000 ± 0%          ~ (p=1.000 n=10) ¹
GridDiskFunc-16                    792.0 ± 0%        792.0 ± 0%          ~ (p=1.000 n=10) ¹
GridDisk-16                        792.0 ± 0%        792.0 ± 0%          ~ (p=1.000 n=10) ¹
GridDiskDistancesFunc-16          2048.0 ± 0%        936.0 ± 0%    -54.30% (p=0.000 n=10)
GridDiskDistances-16              2048.0 ± 0%        936.0 ± 0%    -54.30% (p=0.000 n=10)
GridDiskDistancesSafeFunc-16     2.000Ki ± 0%      8.797Ki ± 0%   +339.84% (p=0.000 n=10)
GridDiskDistancesSafe-16         2.000Ki ± 0%      8.797Ki ± 0%   +339.84% (p=0.000 n=10)
GridDiskDistancesUnsafeFunc-16    2048.0 ± 0%        936.0 ± 0%    -54.30% (p=0.000 n=10)
GridDiskDistancesUnsafe-16        2048.0 ± 0%        936.0 ± 0%    -54.30% (p=0.000 n=10)
GridRingFunc-16                    264.0 ± 0%        264.0 ± 0%          ~ (p=1.000 n=10) ¹
GridRing-16                        264.0 ± 0%        264.0 ± 0%          ~ (p=1.000 n=10) ¹
GridRingUnsafeFunc-16              264.0 ± 0%        264.0 ± 0%          ~ (p=1.000 n=10) ¹
GridRingUnsafe-16                  264.0 ± 0%        264.0 ± 0%          ~ (p=1.000 n=10) ¹
GridDisksUnsafe-16               19.52Ki ± 0%      19.52Ki ± 0%          ~ (p=1.000 n=10) ¹
GridDistanceFunc-16                8.000 ± 0%        0.000 ± 0%   -100.00% (p=0.000 n=10)
GridDistance-16                    8.000 ± 0%        0.000 ± 0%   -100.00% (p=0.000 n=10)
GridPathFunc-16                    80.00 ± 0%        72.00 ± 0%    -10.00% (p=0.000 n=10)
GridPath-16                        80.00 ± 0%        72.00 ± 0%    -10.00% (p=0.000 n=10)
IsNeighbor-16                      4.000 ± 0%        0.000 ± 0%   -100.00% (p=0.000 n=10)
CellToLocalIJ-16                   24.00 ± 0%        16.00 ± 0%    -33.33% (p=0.000 n=10)
LocalIJToCell-16                  24.000 ± 0%        8.000 ± 0%    -66.67% (p=0.000 n=10)
IcosahedronFaces-16                56.00 ± 0%        40.00 ± 0%    -28.57% (p=0.000 n=10)
CellToVertex-16                   16.000 ± 0%        8.000 ± 0%    -50.00% (p=0.000 n=10)
CellVertex-16                     16.000 ± 0%        8.000 ± 0%    -50.00% (p=0.000 n=10)
CellToVertexes-16                  72.00 ± 0%        72.00 ± 0%          ~ (p=1.000 n=10) ¹
CellVertexes-16                    72.00 ± 0%        72.00 ± 0%          ~ (p=1.000 n=10) ¹
VertexToLatLng-16                  32.00 ± 0%        32.00 ± 0%          ~ (p=1.000 n=10) ¹
VertexLatLng-16                    32.00 ± 0%        32.00 ± 0%          ~ (p=1.000 n=10) ¹
IsValidVertexFunc-16               0.000 ± 0%        0.000 ± 0%          ~ (p=1.000 n=10) ¹
VertexIsValid-16                   0.000 ± 0%        0.000 ± 0%          ~ (p=1.000 n=10) ¹
VertexResolution-16                0.000 ± 0%        0.000 ± 0%          ~ (p=1.000 n=10) ¹
VertexIndexDigit-16                4.000 ± 0%        0.000 ± 0%   -100.00% (p=0.000 n=10)
VertexString-16                    32.00 ± 0%        32.00 ± 0%          ~ (p=1.000 n=10) ¹
VertexMarshalText-16               56.00 ± 0%        56.00 ± 0%          ~ (p=1.000 n=10) ¹
VertexFromString-16                8.000 ± 0%        8.000 ± 0%          ~ (p=1.000 n=10) ¹
DirectedEdge-16                   16.000 ± 0%        8.000 ± 0%    -50.00% (p=0.000 n=10)
DirectedEdges-16                   72.00 ± 0%        72.00 ± 0%          ~ (p=1.000 n=10) ¹
DirectedEdgeCells-16               40.00 ± 0%        40.00 ± 0%          ~ (p=1.000 n=10) ¹
DirectedEdgeOrigin-16             16.000 ± 0%        8.000 ± 0%    -50.00% (p=0.000 n=10)
DirectedEdgeDestination-16        16.000 ± 0%        8.000 ± 0%    -50.00% (p=0.000 n=10)
DirectedEdgeReverse-16            16.000 ± 0%        8.000 ± 0%    -50.00% (p=0.000 n=10)
DirectedEdgeIsValid-16             0.000 ± 0%        0.000 ± 0%          ~ (p=1.000 n=10) ¹
DirectedEdgeResolution-16          0.000 ± 0%        0.000 ± 0%          ~ (p=1.000 n=10) ¹
DirectedEdgeIndexDigit-16          4.000 ± 0%        0.000 ± 0%   -100.00% (p=0.000 n=10)
DirectedEdgeBoundary-16           232.00 ± 0%        72.00 ± 0%    -68.97% (p=0.000 n=10)
DirectedEdgeString-16              32.00 ± 0%        32.00 ± 0%          ~ (p=1.000 n=10) ¹
DirectedEdgeMarshalText-16         56.00 ± 0%        56.00 ± 0%          ~ (p=1.000 n=10) ¹
DirectedEdgeFromString-16          8.000 ± 0%        8.000 ± 0%          ~ (p=1.000 n=10) ¹
PolygonToCells-16                6.438Ki ± 0%     33.688Ki ± 0%   +423.30% (p=0.000 n=10)
GeoPolygonCells-16               6.438Ki ± 0%     33.688Ki ± 0%   +423.30% (p=0.000 n=10)
PolygonToCellsExperimental-16    3.188Ki ± 0%      5.023Ki ± 0%    +57.60% (p=0.000 n=10)
CellsToMultiPolygon-16            1016.0 ± 0%      36288.0 ± 0%  +3471.65% (p=0.000 n=10)
geomean                                       ²                  ?                        ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean

                               │      cgo      │                     go                     │
                               │   allocs/op   │  allocs/op    vs base                      │
LatLngToCell-16                   3.000 ± 0%       1.000 ± 0%    -66.67% (p=0.000 n=10)
LatLngToCellString-16             4.000 ± 0%       2.000 ± 0%    -50.00% (p=0.000 n=10)
LatLngCell-16                     3.000 ± 0%       1.000 ± 0%    -66.67% (p=0.000 n=10)
NewLatLng-16                      1.000 ± 0%       1.000 ± 0%          ~ (p=1.000 n=10) ¹
LatLngString-16                   2.000 ± 0%       2.000 ± 0%          ~ (p=1.000 n=10) ¹
CellToLatLng-16                   2.000 ± 0%       1.000 ± 0%    -50.00% (p=0.000 n=10)
CellLatLng-16                     2.000 ± 0%       1.000 ± 0%    -50.00% (p=0.000 n=10)
CellToString-16                   2.000 ± 0%       2.000 ± 0%          ~ (p=1.000 n=10) ¹
CellString-16                     2.000 ± 0%       2.000 ± 0%          ~ (p=1.000 n=10) ¹
CellMarshalText-16                3.000 ± 0%       3.000 ± 0%          ~ (p=1.000 n=10) ¹
CellFromString-16                 1.000 ± 0%       1.000 ± 0%          ~ (p=1.000 n=10) ¹
IndexFromString-16                1.000 ± 0%       1.000 ± 0%          ~ (p=1.000 n=10) ¹
IndexToString-16                  2.000 ± 0%       2.000 ± 0%          ~ (p=1.000 n=10) ¹
Resolution-16                     0.000 ± 0%       0.000 ± 0%          ~ (p=1.000 n=10) ¹
BaseCellNumberFunc-16             0.000 ± 0%       0.000 ± 0%          ~ (p=1.000 n=10) ¹
BaseCellNumber-16                 0.000 ± 0%       0.000 ± 0%          ~ (p=1.000 n=10) ¹
IsValid-16                        0.000 ± 0%       0.000 ± 0%          ~ (p=1.000 n=10) ¹
IsPentagon-16                     0.000 ± 0%       0.000 ± 0%          ~ (p=1.000 n=10) ¹
IsResClassIII-16                  0.000 ± 0%       0.000 ± 0%          ~ (p=1.000 n=10) ¹
CellIndexDigit-16                 1.000 ± 0%       0.000 ± 0%   -100.00% (p=0.000 n=10)
NumCells-16                       1.000 ± 0%       1.000 ± 0%          ~ (p=1.000 n=10) ¹
Res0Cells-16                      2.000 ± 0%       2.000 ± 0%          ~ (p=1.000 n=10) ¹
Pentagons-16                      2.000 ± 0%       2.000 ± 0%          ~ (p=1.000 n=10) ¹
Parent-16                         2.000 ± 0%       1.000 ± 0%    -50.00% (p=0.000 n=10)
ImmediateParent-16                2.000 ± 0%       1.000 ± 0%    -50.00% (p=0.000 n=10)
Children-16                       3.000 ± 0%       2.000 ± 0%    -33.33% (p=0.000 n=10)
ImmediateChildren-16              3.000 ± 0%       2.000 ± 0%    -33.33% (p=0.000 n=10)
CenterChild-16                    2.000 ± 0%       1.000 ± 0%    -50.00% (p=0.000 n=10)
CellToChildPos-16                 1.000 ± 0%       0.000 ± 0%   -100.00% (p=0.000 n=10)
ChildPos-16                       1.000 ± 0%       0.000 ± 0%   -100.00% (p=0.000 n=10)
ChildPosToCellFunc-16             2.000 ± 0%       1.000 ± 0%    -50.00% (p=0.000 n=10)
ChildPosToCell-16                 2.000 ± 0%       1.000 ± 0%    -50.00% (p=0.000 n=10)
CompactCells-16                   2.000 ± 0%       7.000 ± 0%   +250.00% (p=0.000 n=10)
UncompactCells-16                 3.000 ± 0%       2.000 ± 0%    -33.33% (p=0.000 n=10)
CellToBoundary-16                 3.000 ± 0%       5.000 ± 0%    +66.67% (p=0.000 n=10)
CellBoundary-16                   3.000 ± 0%       5.000 ± 0%    +66.67% (p=0.000 n=10)
CellAreaRads2-16                  2.000 ± 0%       5.000 ± 0%   +150.00% (p=0.000 n=10)
CellAreaKm2-16                    2.000 ± 0%       5.000 ± 0%   +150.00% (p=0.000 n=10)
CellAreaM2-16                     2.000 ± 0%       5.000 ± 0%   +150.00% (p=0.000 n=10)
HexagonAreaAvgKm2-16              2.000 ± 0%       1.000 ± 0%    -50.00% (p=0.000 n=10)
HexagonAreaAvgM2-16               2.000 ± 0%       1.000 ± 0%    -50.00% (p=0.000 n=10)
EdgeLengthRads-16                 2.000 ± 0%       3.000 ± 0%    +50.00% (p=0.000 n=10)
EdgeLengthKm-16                   2.000 ± 0%       3.000 ± 0%    +50.00% (p=0.000 n=10)
EdgeLengthM-16                    2.000 ± 0%       3.000 ± 0%    +50.00% (p=0.000 n=10)
HexagonEdgeLengthAvgKm-16         2.000 ± 0%       1.000 ± 0%    -50.00% (p=0.000 n=10)
HexagonEdgeLengthAvgM-16          2.000 ± 0%       1.000 ± 0%    -50.00% (p=0.000 n=10)
GreatCircleDistanceRads-16        1.000 ± 0%       1.000 ± 0%          ~ (p=1.000 n=10) ¹
GreatCircleDistanceKm-16          1.000 ± 0%       1.000 ± 0%          ~ (p=1.000 n=10) ¹
GreatCircleDistanceM-16           1.000 ± 0%       1.000 ± 0%          ~ (p=1.000 n=10) ¹
GridDiskFunc-16                   2.000 ± 0%       2.000 ± 0%          ~ (p=1.000 n=10) ¹
GridDisk-16                       2.000 ± 0%       2.000 ± 0%          ~ (p=1.000 n=10) ¹
GridDiskDistancesFunc-16         10.000 ± 0%       3.000 ± 0%    -70.00% (p=0.000 n=10)
GridDiskDistances-16             10.000 ± 0%       3.000 ± 0%    -70.00% (p=0.000 n=10)
GridDiskDistancesSafeFunc-16      10.00 ± 0%       20.00 ± 0%   +100.00% (p=0.000 n=10)
GridDiskDistancesSafe-16          10.00 ± 0%       20.00 ± 0%   +100.00% (p=0.000 n=10)
GridDiskDistancesUnsafeFunc-16   10.000 ± 0%       3.000 ± 0%    -70.00% (p=0.000 n=10)
GridDiskDistancesUnsafe-16       10.000 ± 0%       3.000 ± 0%    -70.00% (p=0.000 n=10)
GridRingFunc-16                   2.000 ± 0%       2.000 ± 0%          ~ (p=1.000 n=10) ¹
GridRing-16                       2.000 ± 0%       2.000 ± 0%          ~ (p=1.000 n=10) ¹
GridRingUnsafeFunc-16             2.000 ± 0%       2.000 ± 0%          ~ (p=1.000 n=10) ¹
GridRingUnsafe-16                 2.000 ± 0%       2.000 ± 0%          ~ (p=1.000 n=10) ¹
GridDisksUnsafe-16                3.000 ± 0%       3.000 ± 0%          ~ (p=1.000 n=10) ¹
GridDistanceFunc-16               1.000 ± 0%       0.000 ± 0%   -100.00% (p=0.000 n=10)
GridDistance-16                   1.000 ± 0%       0.000 ± 0%   -100.00% (p=0.000 n=10)
GridPathFunc-16                   3.000 ± 0%       2.000 ± 0%    -33.33% (p=0.000 n=10)
GridPath-16                       3.000 ± 0%       2.000 ± 0%    -33.33% (p=0.000 n=10)
IsNeighbor-16                     1.000 ± 0%       0.000 ± 0%   -100.00% (p=0.000 n=10)
CellToLocalIJ-16                  2.000 ± 0%       1.000 ± 0%    -50.00% (p=0.000 n=10)
LocalIJToCell-16                  3.000 ± 0%       1.000 ± 0%    -66.67% (p=0.000 n=10)
IcosahedronFaces-16               4.000 ± 0%       2.000 ± 0%    -50.00% (p=0.000 n=10)
CellToVertex-16                   2.000 ± 0%       1.000 ± 0%    -50.00% (p=0.000 n=10)
CellVertex-16                     2.000 ± 0%       1.000 ± 0%    -50.00% (p=0.000 n=10)
CellToVertexes-16                 2.000 ± 0%       2.000 ± 0%          ~ (p=1.000 n=10) ¹
CellVertexes-16                   2.000 ± 0%       2.000 ± 0%          ~ (p=1.000 n=10) ¹
VertexToLatLng-16                 2.000 ± 0%       2.000 ± 0%          ~ (p=1.000 n=10) ¹
VertexLatLng-16                   2.000 ± 0%       2.000 ± 0%          ~ (p=1.000 n=10) ¹
IsValidVertexFunc-16              0.000 ± 0%       0.000 ± 0%          ~ (p=1.000 n=10) ¹
VertexIsValid-16                  0.000 ± 0%       0.000 ± 0%          ~ (p=1.000 n=10) ¹
VertexResolution-16               0.000 ± 0%       0.000 ± 0%          ~ (p=1.000 n=10) ¹
VertexIndexDigit-16               1.000 ± 0%       0.000 ± 0%   -100.00% (p=0.000 n=10)
VertexString-16                   2.000 ± 0%       2.000 ± 0%          ~ (p=1.000 n=10) ¹
VertexMarshalText-16              3.000 ± 0%       3.000 ± 0%          ~ (p=1.000 n=10) ¹
VertexFromString-16               1.000 ± 0%       1.000 ± 0%          ~ (p=1.000 n=10) ¹
DirectedEdge-16                   2.000 ± 0%       1.000 ± 0%    -50.00% (p=0.000 n=10)
DirectedEdges-16                  2.000 ± 0%       2.000 ± 0%          ~ (p=1.000 n=10) ¹
DirectedEdgeCells-16              2.000 ± 0%       2.000 ± 0%          ~ (p=1.000 n=10) ¹
DirectedEdgeOrigin-16             2.000 ± 0%       1.000 ± 0%    -50.00% (p=0.000 n=10)
DirectedEdgeDestination-16        2.000 ± 0%       1.000 ± 0%    -50.00% (p=0.000 n=10)
DirectedEdgeReverse-16            2.000 ± 0%       1.000 ± 0%    -50.00% (p=0.000 n=10)
DirectedEdgeIsValid-16            0.000 ± 0%       0.000 ± 0%          ~ (p=1.000 n=10) ¹
DirectedEdgeResolution-16         0.000 ± 0%       0.000 ± 0%          ~ (p=1.000 n=10) ¹
DirectedEdgeIndexDigit-16         1.000 ± 0%       0.000 ± 0%   -100.00% (p=0.000 n=10)
DirectedEdgeBoundary-16           3.000 ± 0%       3.000 ± 0%          ~ (p=1.000 n=10) ¹
DirectedEdgeString-16             2.000 ± 0%       2.000 ± 0%          ~ (p=1.000 n=10) ¹
DirectedEdgeMarshalText-16        3.000 ± 0%       3.000 ± 0%          ~ (p=1.000 n=10) ¹
DirectedEdgeFromString-16         1.000 ± 0%       1.000 ± 0%          ~ (p=1.000 n=10) ¹
PolygonToCells-16                 4.000 ± 0%      98.000 ± 0%  +2350.00% (p=0.000 n=10)
GeoPolygonCells-16                4.000 ± 0%      98.000 ± 0%  +2350.00% (p=0.000 n=10)
PolygonToCellsExperimental-16     4.000 ± 0%      24.000 ± 0%   +500.00% (p=0.000 n=10)
CellsToMultiPolygon-16            5.000 ± 0%     188.000 ± 0%  +3660.00% (p=0.000 n=10)
geomean                                      ²                 ?                        ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean
```