### PR TITLE
perf: fold projection trig into precomputed tables and fused IJK descent

### DIFF
--- a/x/h3go/faceijk.go
+++ b/x/h3go/faceijk.go
@@ -460,19 +460,46 @@ func (v vec2d) almostEquals(b vec2d) bool {
 	return math.Abs(v.x-b.x) < fltEpsilon && math.Abs(v.y-b.y) < fltEpsilon
 }
 
+// Precomputed trig for toVec3's inverse gnomonic projection, so the hot path
+// uses multiply-adds and a single sqrt instead of atan2/atan/sin/cos.
+var (
+	ap7RotCos = math.Cos(mAP7RotRads)
+	ap7RotSin = math.Sin(mAP7RotRads)
+
+	faceAxis0Cos, faceAxis0Sin = faceAxis0Trig()
+)
+
+// faceAxis0Trig precomputes the cosine and sine of each face's axis-0 azimuth.
+func faceAxis0Trig() (cos, sin [NumIcosaFaces]float64) {
+	for i := range faceAxesAzRadsCII {
+		cos[i] = math.Cos(faceAxesAzRadsCII[i][0])
+		sin[i] = math.Sin(faceAxesAzRadsCII[i][0])
+	}
+
+	return cos, sin
+}
+
 // toVec3 converts a 2D Hex coordinate on a face into a 3D unit vector. It is the
 // inverse of the gnomonic projection: the radius is inverse-scaled per
 // resolution (and by a further third for substrate grids), the gnomonic scaling
-// is undone with atan, and the result is placed at the computed azimuth from the
-// face center. A point at the face center maps to the face center vector.
+// is undone, and the result is placed at the computed azimuth from the face
+// center. A point at the face center maps to the face center vector.
+//
+// The angle work is done with precomputed cos/sin rather than atan2/atan/sin/cos:
+// the in-plane angle's cos/sin come straight from the vector, the per-resolution
+// and per-face rotations fold in via angle-addition, and the inverse gnomonic
+// uses cos(atan r)=1/√(1+r²), sin(atan r)=r/√(1+r²).
 func (v vec2d) toVec3(face, res int, substrate bool) vec3d {
-	r := v.mag()
-	if r < epsilon {
+	mag := v.mag()
+	if mag < epsilon {
 		return faceCenterPoint[face]
 	}
 
-	theta := math.Atan2(v.y, v.x)
+	// cos/sin of the in-plane angle theta = atan2(y, x), taken directly.
+	cosTheta := v.x / mag
+	sinTheta := v.y / mag
 
+	r := mag
 	for range res {
 		r *= mRSqrt7
 	}
@@ -489,17 +516,29 @@ func (v vec2d) toVec3(face, res int, substrate bool) vec3d {
 	}
 
 	r *= res0UGnomonic
-	r = math.Atan(r)
 
+	// Class III rotates the angle by mAP7RotRads before projecting (theta += rot).
 	if !substrate && isResClassIII(res) {
-		theta = posAngleRads(theta + mAP7RotRads)
+		cosTheta, sinTheta = cosTheta*ap7RotCos-sinTheta*ap7RotSin,
+			sinTheta*ap7RotCos+cosTheta*ap7RotSin
 	}
 
-	theta = posAngleRads(faceAxesAzRadsCII[face][0] - theta)
+	// Azimuth from the face center is faceAxis0 - theta; expand cos/sin of the
+	// difference from the precomputed face-axis trig.
+	cosA := faceAxis0Cos[face]
+	sinA := faceAxis0Sin[face]
+	cosAz := cosA*cosTheta + sinA*sinTheta
+	sinAz := sinA*cosTheta - cosA*sinTheta
+
+	// Inverse gnomonic: the projected angle is atan(r); use the half-angle
+	// identities to skip atan and the following sin/cos.
+	invHyp := 1.0 / math.Sqrt(1.0+r*r)
+	cosR := invHyp
+	sinR := r * invHyp
 
 	north, east := faceCenterPoint[face].tangentBasis()
-	dir := north.linComb(math.Cos(theta), math.Sin(theta), east)
-	out := faceCenterPoint[face].linComb(math.Cos(r), math.Sin(r), dir)
+	dir := north.linComb(cosAz, sinAz, east)
+	out := faceCenterPoint[face].linComb(cosR, sinR, dir)
 	out.normalize()
 
 	return out
@@ -738,13 +777,24 @@ func (c Cell) toFaceIjkWithInitializedFijk(fijk faceIJK) (faceIJK, bool) {
 	ijk := fijk.coord
 
 	for r := 1; r <= res; r++ {
-		if isResClassIII(r) { // rotate ccw
-			ijk.downAp7()
+		// Down-aperture-7 into the finer grid, then step to the indexing digit's
+		// neighbor. downAp7/downAp7r and neighbor each normalize; here they are
+		// fused so a single normalize closes the iteration, which is exact
+		// because normalize is invariant to a uniform offset.
+		if isResClassIII(r) { // Class III: rotate ccw
+			ijk = coordIJK{i: 3*ijk.i + ijk.j, j: 3*ijk.j + ijk.k, k: ijk.i + 3*ijk.k}
 		} else { // Class II: rotate cw
-			ijk.downAp7r()
+			ijk = coordIJK{i: 3*ijk.i + ijk.k, j: ijk.i + 3*ijk.j, k: ijk.j + 3*ijk.k}
 		}
 
-		ijk = ijk.neighbor(indexDigit(c, r))
+		if digit := indexDigit(c, r); digit > centerDigit && digit < invalidDigit {
+			unit := unitVecs[digit]
+			ijk.i += unit.i
+			ijk.j += unit.j
+			ijk.k += unit.k
+		}
+
+		ijk.normalize()
 	}
 
 	fijk.coord = ijk

--- a/x/h3go/faceijk_test.go
+++ b/x/h3go/faceijk_test.go
@@ -18,6 +18,7 @@ package h3go
 
 import (
 	"errors"
+	"math"
 	"testing"
 )
 
@@ -189,5 +190,25 @@ func TestIcosahedronFacesInvalid(t *testing.T) {
 	overflow := Cell(0x08191d58a34080d2)
 	if _, err := overflow.IcosahedronFaces(); !errors.Is(err, ErrFailed) {
 		t.Fatalf("face-count overflow: got %v, want ErrFailed", err)
+	}
+}
+
+// TestToVec3SubstrateClassIII covers the substrate aperture-7 branch that only
+// fires for a hand-built odd-resolution substrate grid: H3's own builders bump
+// res to Class II first, so no public call reaches it. The projected point must
+// still land on the unit sphere.
+func TestToVec3SubstrateClassIII(t *testing.T) {
+	t.Parallel()
+
+	const classIIIRes = 1 // odd => Class III
+	if !isResClassIII(classIIIRes) {
+		t.Fatalf("res %d should be Class III", classIIIRes)
+	}
+
+	point := vec2d{x: 0.5, y: 0.5}.toVec3(0, classIIIRes, true)
+
+	mag := math.Sqrt(point.x*point.x + point.y*point.y + point.z*point.z)
+	if math.Abs(mag-1) > epsilon {
+		t.Fatalf("substrate Class III point off the unit sphere: mag=%v", mag)
 	}
 }

--- a/x/h3go/grid_test.go
+++ b/x/h3go/grid_test.go
@@ -260,6 +260,16 @@ func TestGridDomainErrors(t *testing.T) {
 	if _, err := origin.GridRing(-1); !errors.Is(err, ErrDomain) {
 		t.Fatalf("GridRing(-1): got %v, want ErrDomain", err)
 	}
+
+	if _, err := GridDisksUnsafe([]Cell{origin}, -1); !errors.Is(err, ErrDomain) {
+		t.Fatalf("GridDisksUnsafe(-1): got %v, want ErrDomain", err)
+	}
+
+	// gridDiskUnsafeInto guards k itself; every public caller validates first,
+	// so this is the only path that reaches the guard.
+	if _, err := origin.gridDiskUnsafeInto(-1, nil); !errors.Is(err, ErrDomain) {
+		t.Fatalf("gridDiskUnsafeInto(-1): got %v, want ErrDomain", err)
+	}
 }
 
 // TestGridPentagonFallback checks that the unsafe variants report ErrPentagon on

--- a/x/h3go/hierarchy.go
+++ b/x/h3go/hierarchy.go
@@ -376,6 +376,10 @@ func CompactCells(in []Cell) ([]Cell, error) {
 	// each pass and handed back as remaining.
 	var next []Cell
 
+	// parents[i] holds the parent of remaining[i], filled fresh each pass by the
+	// validation scan so the run loop can group by it without recomputing.
+	parents := make([]Cell, len(in))
+
 	for len(remaining) > 0 {
 		parentRes := remaining[0].Resolution() - 1
 		if parentRes < 0 {
@@ -388,17 +392,16 @@ func CompactCells(in []Cell) ([]Cell, error) {
 		// in the lowest occupied digit) and pushes any zero padding to the front.
 		slices.Sort(remaining)
 
-		next = next[:0]
+		// Skip zero padding; it never compacts.
+		start := 0
+		for start < len(remaining) && remaining[start] == 0 {
+			start++
+		}
 
-		runStart := 0
-		for runStart < len(remaining) {
-			cell := remaining[runStart]
-			if cell == 0 {
-				// Skip zero padding; it never compacts.
-				runStart++
-				continue
-			}
-
+		// One validation scan: reject reserved bits and resolution errors, and
+		// record every cell's parent for the grouping pass below.
+		for i := start; i < len(remaining); i++ {
+			cell := remaining[i]
 			if reservedBits(cell) != 0 {
 				return nil, ErrCellInvalid
 			}
@@ -408,26 +411,19 @@ func CompactCells(in []Cell) ([]Cell, error) {
 				return nil, err
 			}
 
-			// Extend the run over every following cell with the same parent.
+			parents[i] = parent
+		}
+
+		next = next[:0]
+
+		// Each parent's children are now a contiguous run.
+		for runStart := start; runStart < len(remaining); {
 			runEnd := runStart + 1
-			for runEnd < len(remaining) {
-				sibling := remaining[runEnd]
-				if reservedBits(sibling) != 0 {
-					return nil, ErrCellInvalid
-				}
-
-				siblingParent, err := sibling.Parent(parentRes)
-				if err != nil {
-					return nil, err
-				}
-
-				if siblingParent != parent {
-					break
-				}
-
+			for runEnd < len(remaining) && parents[runEnd] == parents[runStart] {
 				runEnd++
 			}
 
+			parent := parents[runStart]
 			fullCount := parent.fullChildCount()
 			runLen := runEnd - runStart
 


### PR DESCRIPTION
Two hot transforms behind nearly every geometry call are reworked.

toVec3 (the inverse gnomonic projection behind CellToLatLng, CellToBoundary, CellArea*, EdgeLength*, vertex/edge boundaries, and the polygon paths) computed five transcendental calls per invocation (atan2 + atan + two sin/cos pairs). Replace them with algebra:
  - cos/sin of the in-plane angle taken directly from the vector (no atan2);
  - per-face azimuth and the Class III rotation folded in via angle-addition against precomputed cos/sin tables;
  - the inverse gnomonic via cos(atan r)=1/sqrt(1+r^2), sin(atan r)=r/sqrt(1+r^2) (one sqrt, no atan/sin/cos).

toFaceIjkWithInitializedFijk (the forward path behind LatLngToCell, PolygonToCells, and local-IJ) fuses the per-resolution Class II/III digit descent so each digit does a single coordIJK normalize, instead of normalizing the rotated and the translated coordinates separately.

Both transforms are algebraically exact; output differs from C only at the ULP level, well within the parity suite's 1e-5 relative tolerance. All white-box and parity tests pass.

benchstat, pure-Go, f5c493f -> toVec3 fold (Apple M3 Max, count=10):

```
                              │    sec/op    │   sec/op     vs base                │
CellToLatLng-16                  160.4n ± 2%   126.4n ± 1%  -21.20% (p=0.000 n=10)
CellLatLng-16                    160.6n ± 0%   126.4n ± 2%  -21.35% (p=0.000 n=10)
CellToBoundary-16                648.1n ± 1%   438.9n ± 2%  -32.28% (p=0.000 n=10)
CellBoundary-16                  647.2n ± 1%   463.8n ± 3%  -28.35% (p=0.000 n=10)
CellAreaRads2-16                 813.8n ± 0%   631.3n ± 3%  -22.43% (p=0.000 n=10)
CellAreaKm2-16                   814.5n ± 1%   612.9n ± 2%  -24.76% (p=0.000 n=10)
CellAreaM2-16                    823.4n ± 3%   610.4n ± 1%  -25.87% (p=0.000 n=10)
EdgeLengthRads-16                394.0n ± 1%   329.4n ± 3%  -16.38% (p=0.000 n=10)
EdgeLengthKm-16                  395.2n ± 3%   327.1n ± 3%  -17.22% (p=0.000 n=10)
EdgeLengthM-16                   397.2n ± 1%   331.0n ± 1%  -16.66% (p=0.000 n=10)
VertexToLatLng-16                216.8n ± 2%   194.4n ± 2%  -10.33% (p=0.000 n=10)
VertexLatLng-16                  222.2n ± 2%   190.7n ± 0%  -14.16% (p=0.000 n=10)
DirectedEdgeBoundary-16          392.8n ± 3%   316.4n ± 2%  -19.43% (p=0.000 n=10)
PolygonToCells-16                190.0µ ± 3%   163.5µ ± 2%  -13.97% (p=0.000 n=10)
GeoPolygonCells-16               190.8µ ± 3%   162.8µ ± 1%  -14.67% (p=0.000 n=10)
PolygonToCellsExperimental-16   119.17µ ± 4%   96.75µ ± 1%  -18.82% (p=0.000 n=10)
CellsToMultiPolygon-16           41.86µ ± 1%   36.02µ ± 1%  -13.97% (p=0.000 n=10)
geomean                          873.1n        718.3n       -17.74%
```

benchstat, pure-Go, toVec3 fold -> + toFaceIjk fusion:

```
                        │   sec/op    │   sec/op     vs base                │
CellToLatLng-16           130.4n ± 1%   115.2n ± 3%  -11.73% (p=0.000 n=10)
CellLatLng-16             131.4n ± 1%   116.9n ± 2%  -11.00% (p=0.000 n=10)
CellToBoundary-16         441.8n ± 1%   421.3n ± 1%   -4.64% (p=0.000 n=10)
CellBoundary-16           443.1n ± 1%   417.6n ± 1%   -5.74% (p=0.000 n=10)
CellAreaRads2-16          610.3n ± 0%   593.0n ± 2%   -2.83% (p=0.001 n=10)
CellAreaKm2-16            633.5n ± 3%   594.1n ± 3%   -6.22% (p=0.000 n=10)
CellAreaM2-16            613.7n ± 5%   597.7n ± 1%   -2.61% (p=0.000 n=10)
EdgeLengthRads-16         324.7n ± 3%   300.5n ± 1%   -7.44% (p=0.000 n=10)
EdgeLengthKm-16           324.9n ± 1%   300.0n ± 0%   -7.68% (p=0.000 n=10)
EdgeLengthM-16            327.2n ± 2%   303.1n ± 1%   -7.35% (p=0.000 n=10)
VertexToLatLng-16         190.1n ± 0%   176.2n ± 0%   -7.31% (p=0.000 n=10)
VertexLatLng-16           189.7n ± 0%   179.5n ± 4%   -5.35% (p=0.000 n=10)
DirectedEdgeBoundary-16   308.4n ± 1%   283.6n ± 1%   -8.07% (p=0.000 n=10)
PolygonToCells-16         162.9µ ± 1%   156.9µ ± 3%   -3.68% (p=0.004 n=10)
GeoPolygonCells-16        162.4µ ± 3%   155.7µ ± 0%   -4.13% (p=0.000 n=10)
CellsToMultiPolygon-16    35.20µ ± 0%   33.81µ ± 1%   -3.97% (p=0.000 n=10)
geomean                   924.5n        866.5n        -6.27%
```

benchstat -col /impl, final pure-Go standing vs the cgo reference:

```
                        │     cgo     │            go (this branch)           │
CellToLatLng-16           147.0n ± 2%   115.2n ± 3%  -21.67% (p=0.000 n=10)
CellLatLng-16             149.0n ± 1%   116.9n ± 2%  -21.51% (p=0.000 n=10)
CellToBoundary-16         460.9n ± 1%   421.3n ± 1%   -8.59% (p=0.000 n=10)
CellBoundary-16           461.5n ± 3%   417.6n ± 1%   -9.51% (p=0.000 n=10)
CellAreaRads2-16          559.2n ± 1%   593.0n ± 2%   +6.05% (p=0.000 n=10)
CellAreaKm2-16            558.1n ± 1%   594.1n ± 3%   +6.46% (p=0.000 n=10)
CellAreaM2-16             560.8n ± 1%   597.7n ± 1%   +6.59% (p=0.000 n=10)
EdgeLengthRads-16         284.6n ± 1%   300.5n ± 1%   +5.57% (p=0.000 n=10)
EdgeLengthKm-16           285.4n ± 1%   300.0n ± 0%   +5.10% (p=0.000 n=10)
EdgeLengthM-16            286.6n ± 0%   303.1n ± 1%   +5.77% (p=0.000 n=10)
VertexToLatLng-16         176.2n ± 1%   176.2n ± 0%        ~ (p=0.782 n=10)
VertexLatLng-16           176.6n ± 1%   179.5n ± 4%   +1.67% (p=0.009 n=10)
DirectedEdgeBoundary-16   281.7n ± 1%   283.6n ± 1%   +0.66% (p=0.020 n=10)
PolygonToCells-16         136.9µ ± 1%   156.9µ ± 3%  +14.58% (p=0.000 n=10)
GeoPolygonCells-16        136.6µ ± 1%   155.7µ ± 0%  +13.92% (p=0.000 n=10)
CellsToMultiPolygon-16    26.54µ ± 1%   33.81µ ± 1%  +27.36% (p=0.000 n=10)
geomean                   855.7n        866.5n        +1.26%
```

The geometry group now sits at parity with cgo (geomean +1.3%): the per-cell conversions (CellToLatLng/Boundary) beat cgo, while the polygon paths stay projection-bound and trail cgo by ~14-27%.

Also bring x/h3go to 100% statement coverage:
  - CompactCells now validates each cell and records its parent in a single scan, then groups each parent's contiguous run, removing the duplicated sibling validation branches that no sorted input could ever reach.
  - add negative-k cases for GridDisksUnsafe and the internal gridDiskUnsafeInto guard, plus a white-box test for toVec3's substrate Class III branch.