### PR TITLE
perf: fold forward gnomonic projection (toHex2d) into algebra

### DIFF
--- a/x/h3go/faceijk.go
+++ b/x/h3go/faceijk.go
@@ -86,63 +86,74 @@ func (v vec3d) tangentBasis() (north, east vec3d) {
 	return north, east
 }
 
-// azimuthRads returns the azimuth, in radians, of point p2 as seen from point v,
-// measured in v's local tangent plane (clockwise from north). It is used to find
-// the angle of a geographic point relative to a face center.
-func (v vec3d) azimuthRads(p2 vec3d) float64 {
-	north, east := v.tangentBasis()
-	p2Proj := p2.linComb(1.0, -p2.dot(v), v)
-	p2Proj.normalize()
-
-	return math.Atan2(p2Proj.dot(east), p2Proj.dot(north))
-}
-
-// posAngleRads normalizes an angle in radians into the range [0, 2π).
-func posAngleRads(rads float64) float64 {
-	tmp := rads
-	if rads < 0 {
-		tmp += m2PI
-	}
-
-	if tmp >= m2PI {
-		tmp -= m2PI
-	}
-
-	return tmp
-}
+// faceCenterDistSq is the squared chord distance below which a point is treated
+// as sitting on its face center, where the azimuth is singular. It mirrors the
+// original acos(1-sqd/2) < epsilon guard: acos(1-sqd/2) < epsilon ⟺
+// sqd < 2(1-cos epsilon). For epsilon this small that exact form underflows to
+// zero (cos(1e-16) rounds to 1), so use its leading-order equivalent, epsilon².
+const faceCenterDistSq = epsilon * epsilon
 
 // toHex2d gnomonically projects the unit vector v onto its closest icosahedron
 // face and returns that face plus the point's 2D Hex coordinates (centered on
 // the face center) at the given resolution. The radius is scaled by √7 per
 // resolution and the angle is rotated for odd (Class III) resolutions. A point
 // at the face center maps to the origin.
+//
+// The angle work uses precomputed cos/sin instead of acos/atan2/tan/sin/cos: the
+// azimuth's cos/sin come straight from the tangent-plane components (so neither
+// the tangent basis nor the projection need normalizing — the scale cancels in
+// the ratio), the per-face and Class III rotations fold in via angle-subtraction,
+// and the gnomonic tan(acos x) reduces to √(1−x²)/x.
 func (v vec3d) toHex2d(res int) (face int, hex vec2d) {
 	var sqd float64
 
 	face, sqd = v.closestFace()
 
-	r := math.Acos(1 - sqd*0.5)
-	if r < epsilon {
+	// Near the face center the azimuth is singular (the tangent-plane projection
+	// vanishes); the center itself maps to the origin.
+	if sqd < faceCenterDistSq {
 		return face, hex
 	}
 
-	theta := posAngleRads(
-		faceAxesAzRadsCII[face][0] -
-			posAngleRads(faceCenterPoint[face].azimuthRads(v)))
+	// Azimuth of v from the face center, taken as cos/sin from the tangent-plane
+	// components. north and the projection are left un-normalized: both the north
+	// and east components scale by the same factor, which cancels in N/hyp, E/hyp.
+	fc := faceCenterPoint[face]
+	pole := vec3d{0, 0, 1}
+	north := pole.linComb(1.0, -pole.dot(fc), fc)
+	east := north.cross(fc)
+	proj := v.linComb(1.0, -v.dot(fc), fc)
+	nComp := proj.dot(north)
+	eComp := proj.dot(east)
+	hyp := math.Sqrt(nComp*nComp + eComp*eComp)
+	cosAz := nComp / hyp
+	sinAz := eComp / hyp
 
+	// theta = faceAxis0 - azimuth, expanded via angle-subtraction.
+	cosA := faceAxis0Cos[face]
+	sinA := faceAxis0Sin[face]
+	cosTheta := cosA*cosAz + sinA*sinAz
+	sinTheta := sinA*cosAz - cosA*sinAz
+
+	// Class III rotates the angle by -mAP7RotRads.
 	if isResClassIII(res) {
-		theta = posAngleRads(theta - mAP7RotRads)
+		cosTheta, sinTheta = cosTheta*ap7RotCos+sinTheta*ap7RotSin,
+			sinTheta*ap7RotCos-cosTheta*ap7RotSin
 	}
 
-	r = math.Tan(r)
+	// Gnomonic scaling: r = tan(acos x) = √(1−x²)/x with x = 1 − sqd/2. The
+	// √((sqd/2)(2−sqd/2)) form is (1−x)(1+x), avoiding cancellation near center.
+	halfSqd := sqd * 0.5
+	x := 1 - halfSqd
+	r := math.Sqrt(halfSqd*(2-halfSqd)) / x
 	r *= invRes0UGnomonic
 
 	for range res {
 		r *= mSqrt7
 	}
 
-	hex.x = r * math.Cos(theta)
-	hex.y = r * math.Sin(theta)
+	hex.x = r * cosTheta
+	hex.y = r * sinTheta
 
 	return face, hex
 }


### PR DESCRIPTION
toHex2d is the forward gnomonic projection behind LatLngToCell, PolygonToCells, and local-IJ -> cell. Like the earlier toVec3 work it computed the angle and radius with transcendentals: acos for the angular distance, atan2 (inside azimuthRads) for the azimuth, tan for the gnomonic scaling, and a final sin/cos pair, plus two vec3d.normalize() sqrts (the tangent basis and the projection).

Replace them with algebra:
  - the azimuth's cos/sin come straight from the tangent-plane components (cosAz = N/hyp, sinAz = E/hyp) instead of atan2 -> cos/sin; because only the N/E ratio is used, neither the tangent basis nor the projection needs normalizing -- both scale by the same factor, which cancels (drops 2 sqrt);
  - the per-face azimuth offset and the Class III rotation fold in via angle-subtraction against the precomputed faceAxis0Cos/Sin and ap7Rot tables;
  - the gnomonic tan(acos x) reduces to sqrt(1-x^2)/x with x = 1 - sqd/2, written as sqrt((sqd/2)(2-sqd/2))/x = (1-x)(1+x) to avoid cancellation near center.

Five transcendentals + 2 normalize sqrts become 2 sqrt. The transform is algebraically exact; output differs from C only at the ULP level, within the parity suite's 1e-5 tolerance. azimuthRads and posAngleRads are now unused and removed. All white-box and parity tests pass; package stays at 100% coverage.

NOTE on the face-center guard: the old `acos(1-sqd/2) < epsilon` short-circuit (the azimuth is singular at the face center, where the tangent projection vanishes) is re-expressed on sqd as `sqd < epsilon*epsilon`. The exact form 2(1-cos epsilon) underflows to 0 at epsilon=1e-16 (cos(1e-16) rounds to 1), so its leading-order equivalent epsilon^2 is used; without a working guard a point exactly on a face center divides 0/0 and yields NaN coordinates.

benchstat, pure-Go, 4953a75 -> this commit (Apple M3 Max, count=10):
```
                              │   sec/op    │   sec/op     vs base                │
LatLngToCell-16                 225.2n ± 0%   188.6n ± 1%  -16.27% (p=0.000 n=10)
LatLngToCellString-16          254.5n ± 2%   212.5n ± 3%  -16.50% (p=0.000 n=10)
LatLngCell-16                   226.2n ± 1%   187.5n ± 1%  -17.10% (p=0.000 n=10)
LocalIJToCell-16               107.3n ± 1%   106.4n ± 1%   -0.88% (p=0.037 n=10)
PolygonToCells-16              161.0µ ± 5%   155.5µ ± 2%   -3.42% (p=0.000 n=10)
GeoPolygonCells-16            160.6µ ± 2%   155.5µ ± 1%   -3.14% (p=0.000 n=10)
PolygonToCellsExperimental-16  93.50µ ± 2%   93.75µ ± 1%        ~ (p=0.315 n=10)
geomean                        3.190µ        2.921µ        -8.46%
```
benchstat -col /impl, final pure-Go standing vs the cgo reference:
```
                              │     cgo      │                 go                  │
                              │    sec/op    │   sec/op     vs base                │
LatLngToCell-16                 242.5n ± 4%   188.6n ± 1%  -22.26% (p=0.000 n=10)
LatLngToCellString-16           278.5n ± 3%   212.5n ± 3%  -23.68% (p=0.000 n=10)
LatLngCell-16                   241.4n ± 2%   187.5n ± 1%  -22.29% (p=0.000 n=10)
LocalIJToCell-16                146.6n ± 1%   106.4n ± 1%  -27.42% (p=0.000 n=10)
PolygonToCells-16               137.4µ ± 1%   155.5µ ± 2%  +13.12% (p=0.000 n=10)
GeoPolygonCells-16              138.4µ ± 2%   155.5µ ± 1%  +12.41% (p=0.000 n=10)
PolygonToCellsExperimental-16  204.54µ ± 1%   93.75µ ± 1%  -54.16% (p=0.000 n=10)
geomean                         3.689µ        2.921µ       -20.82%
```

The LatLng->cell and local-IJ->cell conversions now beat cgo by ~22-27%. PolygonToCells / GeoPolygonCells still trail cgo by ~13%, but that gap is allocation-bound (98 allocs vs 4 on the polyfill path), not projection.