### PR TITLE
perf(x/h3go): use `math.Sincos` instead of separate `math.Sin`/`math.Cos` calls

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -27,55 +27,55 @@ var (
 )
 
 func BenchmarkToString(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		addr = cell.String()
 	}
 }
 
 func BenchmarkFromString(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		cell = Cell(IndexFromString("850dab63fffffff"))
 	}
 }
 
 func BenchmarkLatLng_String(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		latlngStr = geo.String()
 	}
 }
 
 func BenchmarkCellToLatLng(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		geo, _ = CellToLatLng(cell)
 	}
 }
 
 func BenchmarkLatLngToCell(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		cell, _ = LatLngToCell(geo, 15)
 	}
 }
 
 func BenchmarkCellToBoundary(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		geoBndry, _ = CellToBoundary(cell)
 	}
 }
 
 func BenchmarkGridDisk(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		cells, _ = cell.GridDisk(10)
 	}
 }
 
 func BenchmarkGridRing(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		cells, _ = cell.GridRing(10)
 	}
 }
 
 func BenchmarkPolyfill(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		cells, _ = PolygonToCells(validGeoPolygonHoles, 13)
 	}
 }
@@ -83,63 +83,63 @@ func BenchmarkPolyfill(b *testing.B) {
 func BenchmarkGridDisksUnsafe(b *testing.B) {
 	cells, _ = PolygonToCells(validGeoPolygonHoles, 12)
 
-	b.ResetTimer()
+	
 
-	for range b.N {
+	for b.Loop() {
 		disks, _ = GridDisksUnsafe(cells, 10)
 	}
 }
 
 func BenchmarkGreatCircleDistanceRads(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		distResult = GreatCircleDistanceRads(geo, geo2)
 	}
 }
 
 func BenchmarkGreatCircleDistanceKm(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		distResult = GreatCircleDistanceKm(geo, geo2)
 	}
 }
 
 func BenchmarkGreatCircleDistanceM(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		distResult = GreatCircleDistanceM(geo, geo2)
 	}
 }
 
 func BenchmarkResolution(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		intResult = cell.Resolution()
 	}
 }
 
 func BenchmarkBaseCellNumber(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		intResult = cell.BaseCellNumber()
 	}
 }
 
 func BenchmarkIsValid(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		boolResult = cell.IsValid()
 	}
 }
 
 func BenchmarkIsPentagon(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		boolResult = cell.IsPentagon()
 	}
 }
 
 func BenchmarkIsResClassIII(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		boolResult = cell.IsResClassIII()
 	}
 }
 
 func BenchmarkIsValidIndex(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		validResult = IsValidIndex(cell)
 	}
 }

--- a/x/h3go/bench_test.go
+++ b/x/h3go/bench_test.go
@@ -1,0 +1,228 @@
+package h3go
+
+import (
+	"strconv"
+	"testing"
+)
+
+// benchResolutions spans both the Class II (even) and Class III (odd) code
+// paths, from the coarsest to the finest resolution.
+var benchResolutions = []int{0, 2, 7, 9, 15}
+
+// benchPoint is a fixed mid-latitude coordinate that projects onto a hexagon
+// (not a face center, pole, or pentagon), so it exercises the common path.
+var benchPoint = LatLng{Lat: 37.7749, Lng: -122.4194}
+
+// Hierarchy benchmarks expand a parent into its children; these bounds keep the
+// hexagon fan-out at 7^(7-3) = 2401 cells per op.
+const (
+	benchParentRes = 3
+	benchChildRes  = 7
+)
+
+// Result sinks
+var (
+	sinkCell     Cell
+	sinkLatLng   LatLng
+	sinkBoundary CellBoundary
+	sinkCells    []Cell
+	sinkInt      int
+	sinkStr      string
+	sinkBool     bool
+)
+
+// benchHexCell derives the hexagon cell covering benchPoint at res.
+func benchHexCell(tb testing.TB, res int) Cell {
+	tb.Helper()
+
+	c, err := LatLngToCell(benchPoint, res)
+	if err != nil {
+		tb.Fatalf("LatLngToCell(%v, %d): %v", benchPoint, res, err)
+	}
+
+	return c
+}
+
+// benchPentCell returns the first pentagon at res.
+func benchPentCell(tb testing.TB, res int) Cell {
+	tb.Helper()
+
+	pents, err := Pentagons(res)
+	if err != nil || len(pents) == 0 {
+		tb.Fatalf("Pentagons(%d): %v", res, err)
+	}
+
+	return pents[0]
+}
+
+// Forward/reverse projections
+
+func BenchmarkLatLngToCell(b *testing.B) {
+	for _, res := range benchResolutions {
+		b.Run(strconv.Itoa(res), func(b *testing.B) {
+			var c Cell
+			for b.Loop() {
+				c, _ = LatLngToCell(benchPoint, res)
+			}
+			sinkCell = c
+		})
+	}
+}
+
+func BenchmarkCellToLatLng(b *testing.B) {
+	for _, res := range benchResolutions {
+		c := benchHexCell(b, res)
+		b.Run(strconv.Itoa(res), func(b *testing.B) {
+			var ll LatLng
+			for b.Loop() {
+				ll, _ = CellToLatLng(c)
+			}
+			sinkLatLng = ll
+		})
+	}
+}
+
+func BenchmarkCellToBoundary(b *testing.B) {
+	for _, res := range benchResolutions {
+		hex := benchHexCell(b, res)
+		pent := benchPentCell(b, res)
+
+		b.Run("hex/"+strconv.Itoa(res), func(b *testing.B) {
+			b.ReportAllocs()
+
+			var bnd CellBoundary
+			for b.Loop() {
+				bnd, _ = CellToBoundary(hex)
+			}
+			sinkBoundary = bnd
+		})
+
+		b.Run("pent/"+strconv.Itoa(res), func(b *testing.B) {
+			b.ReportAllocs()
+
+			var bnd CellBoundary
+			for b.Loop() {
+				bnd, _ = CellToBoundary(pent)
+			}
+			sinkBoundary = bnd
+		})
+	}
+}
+
+// String conversion
+
+func BenchmarkCellFromString(b *testing.B) {
+	s := benchHexCell(b, maxResolution).String()
+
+	var c Cell
+	for b.Loop() {
+		c = CellFromString(s)
+	}
+	sinkCell = c
+}
+
+func BenchmarkCellToString(b *testing.B) {
+	c := benchHexCell(b, maxResolution)
+
+	var s string
+	for b.Loop() {
+		s = c.String()
+	}
+	sinkStr = s
+}
+
+// Introspection
+
+func BenchmarkIsValid(b *testing.B) {
+	c := benchHexCell(b, maxResolution)
+
+	var ok bool
+	for b.Loop() {
+		ok = c.IsValid()
+	}
+	sinkBool = ok
+}
+
+func BenchmarkIsPentagon(b *testing.B) {
+	c := benchPentCell(b, maxResolution)
+
+	var ok bool
+	for b.Loop() {
+		ok = c.IsPentagon()
+	}
+	sinkBool = ok
+}
+
+// Hierarchy/set operations
+
+func BenchmarkParent(b *testing.B) {
+	c := benchHexCell(b, maxResolution)
+
+	var p Cell
+	for b.Loop() {
+		p, _ = c.Parent(benchParentRes)
+	}
+	sinkCell = p
+}
+
+func BenchmarkChildPos(b *testing.B) {
+	c := benchHexCell(b, 12)
+
+	var pos int
+	for b.Loop() {
+		pos, _ = c.ChildPos(benchParentRes)
+	}
+	sinkInt = pos
+}
+
+func BenchmarkChildren(b *testing.B) {
+	hex := benchHexCell(b, benchParentRes)
+	pent := benchPentCell(b, benchParentRes)
+
+	b.Run("hex", func(b *testing.B) {
+		b.ReportAllocs()
+
+		var out []Cell
+		for b.Loop() {
+			out, _ = hex.Children(benchChildRes)
+		}
+		sinkCells = out
+	})
+
+	b.Run("pent", func(b *testing.B) {
+		b.ReportAllocs()
+
+		var out []Cell
+		for b.Loop() {
+			out, _ = pent.Children(benchChildRes)
+		}
+		sinkCells = out
+	})
+}
+
+func BenchmarkUncompactCells(b *testing.B) {
+	in := []Cell{benchHexCell(b, benchParentRes)}
+
+	b.ReportAllocs()
+
+	var out []Cell
+	for b.Loop() {
+		out, _ = UncompactCells(in, benchChildRes)
+	}
+	sinkCells = out
+}
+
+func BenchmarkCompactCells(b *testing.B) {
+	full, err := benchHexCell(b, benchParentRes).Children(benchChildRes)
+	if err != nil {
+		b.Fatalf("Children: %v", err)
+	}
+
+	b.ReportAllocs()
+
+	var out []Cell
+	for b.Loop() {
+		out, _ = CompactCells(full)
+	}
+	sinkCells = out
+}

--- a/x/h3go/faceijk.go
+++ b/x/h3go/faceijk.go
@@ -109,8 +109,9 @@ func (v vec3d) toHex2d(res int) (face int, hex vec2d) {
 		r *= mSqrt7
 	}
 
-	hex.x = r * math.Cos(theta)
-	hex.y = r * math.Sin(theta)
+	sin, cos := math.Sincos(theta)
+	hex.x = r * cos
+	hex.y = r * sin
 
 	return face, hex
 }
@@ -418,8 +419,11 @@ func (v vec2d) toVec3(face, res int, substrate bool) vec3d {
 	theta = posAngleRads(faceAxesAzRadsCII[face][0] - theta)
 
 	north, east := faceCenterPoint[face].tangentBasis()
-	dir := north.linComb(math.Cos(theta), math.Sin(theta), east)
-	out := faceCenterPoint[face].linComb(math.Cos(r), math.Sin(r), dir)
+
+	sinT, cosT := math.Sincos(theta)
+	sinR, cosR := math.Sincos(r)
+	dir := north.linComb(cosT, sinT, east)
+	out := faceCenterPoint[face].linComb(cosR, sinR, dir)
 	out.normalize()
 
 	return out

--- a/x/h3go/latlng.go
+++ b/x/h3go/latlng.go
@@ -55,12 +55,13 @@ func (c Cell) LatLng() (LatLng, error) {
 // --- Vec3d math ---
 
 func latLngToVec3(lat, lng float64) vec3d {
-	r := math.Cos(lat)
+	sinLat, cosLat := math.Sincos(lat)
+	sinLng, cosLng := math.Sincos(lng)
 
 	return vec3d{
-		x: math.Cos(lng) * r,
-		y: math.Sin(lng) * r,
-		z: math.Sin(lat),
+		x: cosLng * cosLat,
+		y: sinLng * cosLat,
+		z: sinLat,
 	}
 }
 


### PR DESCRIPTION
## What

In a few spots the projection code computes both the sine and cosine of the same
angle with two separate calls:

```go
dir := north.linComb(math.Cos(theta), math.Sin(theta), east)
```

`math.Sincos` returns both at once, so this swaps those pairs for a single call in:

- `latLngToVec3` (`latlng.go`)
- `vec3d.toHex2d` (`faceijk.go`)
- `vec2d.toVec3` (`faceijk.go`)

## Why it helps

As I understand it, `math.Sin` and `math.Cos` each do argument-reduction
work before the actual computation, and calling them separately does that work
twice for the same angle. `math.Sincos` does it once. `toVec3` needs sin+cos of
two angles, so it goes from 4 calls down to 2.

## Is it safe

I think so:

- `math.Sincos` gives the same values as calling `Sin` and `Cos` separately, so
  no precision change.
- `x/h3go/paritytest` (compares every result against the cgo h3 reference) still
  passes.
- `go test ./x/h3go/...` passes.
- No change in allocations.

## Results

Roughly 6-10% off `CellToLatLng`, 3-5% off `LatLngToCell`, and a noisier
4-11% off `CellToBoundary`. A couple of rows come out as `~` (within the noise).
Bytes and allocs are unchanged on every benchmark.

Benchmarks that don't touch this code (`IsValid`, `Parent`, `Children`,
`CompactCells`, string conversion, etc.) stay flat. `CompactCells` shows a small
`+2.31%` but it doesn't share any code with this change, so I'm treating that as
noise.

## Note

The first commit just adds the benchmark file I used for the numbers above, it's
tests only.

To reproduce:
```
go install golang.org/x/perf/cmd/benchstat@latest
go test ./x/h3go/ -run='^$' -bench=. -benchmem -count=10
```

Attaching raw benchstat output for thorough evaluation.
```
goos: linux
goarch: amd64
pkg: github.com/uber/h3-go/v4/x/h3go
cpu: 11th Gen Intel(R) Core(TM) i5-11300H @ 3.10GHz
                         │   base.txt   │             sincos.txt              │
                         │    sec/op    │   sec/op     vs base                │
LatLngToCell/0-8           217.6n ±  2%   206.2n ± 3%   -5.19% (p=0.002 n=10)
LatLngToCell/2-8           264.6n ±  1%   254.4n ± 2%   -3.87% (p=0.001 n=10)
LatLngToCell/7-8           361.6n ±  2%   355.4n ± 3%        ~ (p=0.289 n=10)
LatLngToCell/9-8           401.1n ±  2%   388.8n ± 2%   -3.07% (p=0.000 n=10)
LatLngToCell/15-8          521.5n ±  2%   505.6n ± 2%   -3.05% (p=0.000 n=10)
CellToLatLng/0-8           159.4n ±  1%   143.6n ± 2%   -9.94% (p=0.000 n=10)
CellToLatLng/2-8           176.9n ±  1%   160.2n ± 2%   -9.49% (p=0.000 n=10)
CellToLatLng/7-8           211.6n ±  2%   195.3n ± 1%   -7.68% (p=0.000 n=10)
CellToLatLng/9-8           220.4n ±  1%   203.2n ± 1%   -7.83% (p=0.000 n=10)
CellToLatLng/15-8          270.0n ±  2%   253.5n ± 1%   -6.09% (p=0.000 n=10)
CellToBoundary/hex/0-8     1.890µ ±  4%   1.783µ ± 4%   -5.69% (p=0.023 n=10)
CellToBoundary/pent/0-8    1.783µ ±  3%   1.683µ ± 4%   -5.61% (p=0.001 n=10)
CellToBoundary/hex/2-8     2.120µ ±  8%   1.881µ ± 6%  -11.25% (p=0.000 n=10)
CellToBoundary/pent/2-8    1.766µ ±  8%   1.753µ ± 6%        ~ (p=0.210 n=10)
CellToBoundary/hex/7-8     2.110µ ±  4%   1.943µ ± 7%   -7.91% (p=0.011 n=10)
CellToBoundary/pent/7-8    3.736µ ±  4%   3.525µ ± 5%   -5.64% (p=0.007 n=10)
CellToBoundary/hex/9-8     2.099µ ±  7%   1.940µ ± 6%   -7.60% (p=0.005 n=10)
CellToBoundary/pent/9-8    3.816µ ±  5%   3.665µ ± 5%   -3.97% (p=0.005 n=10)
CellToBoundary/hex/15-8    2.178µ ± 11%   2.153µ ± 4%        ~ (p=0.782 n=10)
CellToBoundary/pent/15-8   3.985µ ±  5%   3.801µ ± 5%   -4.63% (p=0.001 n=10)
CellFromString-8           32.06n ±  3%   32.48n ± 1%        ~ (p=0.165 n=10)
CellToString-8             70.09n ±  3%   70.35n ± 2%        ~ (p=1.000 n=10)
IsValid-8                  3.385n ±  1%   3.396n ± 2%        ~ (p=0.988 n=10)
IsPentagon-8               22.32n ±  2%   22.32n ± 2%        ~ (p=0.644 n=10)
Parent-8                   22.09n ±  0%   22.08n ± 1%        ~ (p=0.402 n=10)
ChildPos-8                 38.59n ±  1%   38.74n ± 2%        ~ (p=0.362 n=10)
Children/hex-8             27.63µ ±  3%   27.02µ ± 4%        ~ (p=0.075 n=10)
Children/pent-8            23.49µ ±  5%   23.29µ ± 1%        ~ (p=0.101 n=10)
UncompactCells-8           24.35µ ±  4%   24.48µ ± 2%        ~ (p=0.684 n=10)
CompactCells-8             361.4µ ±  4%   369.8µ ± 3%   +2.31% (p=0.035 n=10)
geomean                    678.5n         653.1n        -3.74%

                         │    base.txt    │              sincos.txt               │
                         │      B/op      │     B/op      vs base                 │
LatLngToCell/0-8             0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
LatLngToCell/2-8             0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
LatLngToCell/7-8             0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
LatLngToCell/9-8             0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
LatLngToCell/15-8            0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
CellToLatLng/0-8             0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
CellToLatLng/2-8             0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
CellToLatLng/7-8             0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
CellToLatLng/9-8             0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
CellToLatLng/15-8            0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
CellToBoundary/hex/0-8       240.0 ± 0%       240.0 ± 0%       ~ (p=1.000 n=10) ¹
CellToBoundary/pent/0-8      240.0 ± 0%       240.0 ± 0%       ~ (p=1.000 n=10) ¹
CellToBoundary/hex/2-8       240.0 ± 0%       240.0 ± 0%       ~ (p=1.000 n=10) ¹
CellToBoundary/pent/2-8      240.0 ± 0%       240.0 ± 0%       ~ (p=1.000 n=10) ¹
CellToBoundary/hex/7-8       240.0 ± 0%       240.0 ± 0%       ~ (p=1.000 n=10) ¹
CellToBoundary/pent/7-8      496.0 ± 0%       496.0 ± 0%       ~ (p=1.000 n=10) ¹
CellToBoundary/hex/9-8       240.0 ± 0%       240.0 ± 0%       ~ (p=1.000 n=10) ¹
CellToBoundary/pent/9-8      496.0 ± 0%       496.0 ± 0%       ~ (p=1.000 n=10) ¹
CellToBoundary/hex/15-8      240.0 ± 0%       240.0 ± 0%       ~ (p=1.000 n=10) ¹
CellToBoundary/pent/15-8     496.0 ± 0%       496.0 ± 0%       ~ (p=1.000 n=10) ¹
CellFromString-8             0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
CellToString-8               16.00 ± 0%       16.00 ± 0%       ~ (p=1.000 n=10) ¹
IsValid-8                    0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
IsPentagon-8                 0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
Parent-8                     0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
ChildPos-8                   0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
Children/hex-8             20.00Ki ± 0%     20.00Ki ± 0%       ~ (p=1.000 n=10) ¹
Children/pent-8            16.00Ki ± 0%     16.00Ki ± 0%       ~ (p=1.000 n=10) ¹
UncompactCells-8           20.00Ki ± 0%     20.00Ki ± 0%       ~ (p=1.000 n=10) ¹
CompactCells-8             93.50Ki ± 0%     93.50Ki ± 0%       ~ (p=1.000 n=10) ¹
geomean                                 ²                 +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                         │   base.txt   │             sincos.txt              │
                         │  allocs/op   │ allocs/op   vs base                 │
LatLngToCell/0-8           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
LatLngToCell/2-8           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
LatLngToCell/7-8           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
LatLngToCell/9-8           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
LatLngToCell/15-8          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
CellToLatLng/0-8           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
CellToLatLng/2-8           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
CellToLatLng/7-8           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
CellToLatLng/9-8           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
CellToLatLng/15-8          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
CellToBoundary/hex/0-8     4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
CellToBoundary/pent/0-8    4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
CellToBoundary/hex/2-8     4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
CellToBoundary/pent/2-8    4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
CellToBoundary/hex/7-8     4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
CellToBoundary/pent/7-8    5.000 ± 0%     5.000 ± 0%       ~ (p=1.000 n=10) ¹
CellToBoundary/hex/9-8     4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
CellToBoundary/pent/9-8    5.000 ± 0%     5.000 ± 0%       ~ (p=1.000 n=10) ¹
CellToBoundary/hex/15-8    4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
CellToBoundary/pent/15-8   5.000 ± 0%     5.000 ± 0%       ~ (p=1.000 n=10) ¹
CellFromString-8           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
CellToString-8             1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
IsValid-8                  0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
IsPentagon-8               0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Parent-8                   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ChildPos-8                 0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Children/hex-8             1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
Children/pent-8            1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
UncompactCells-8           1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
CompactCells-8             65.00 ± 0%     65.00 ± 0%       ~ (p=1.000 n=10) ¹
geomean                               ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```